### PR TITLE
feat: add suspendWithIamAccount to Marketplace AccountsService

### DIFF
--- a/src/Services/AccountsService.php
+++ b/src/Services/AccountsService.php
@@ -2,6 +2,8 @@
 
 namespace NextDeveloper\Marketplace\Services;
 
+use NextDeveloper\IAM\Database\Scopes\AuthorizationScope;
+use NextDeveloper\Marketplace\Database\Models\Accounts;
 use NextDeveloper\Marketplace\Services\AbstractServices\AbstractAccountsService;
 
 /**
@@ -15,4 +17,31 @@ class AccountsService extends AbstractAccountsService
 {
 
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
+
+    public static function suspend(Accounts $account): Accounts
+    {
+        $account->update([
+            'is_service_enabled' => false,
+        ]);
+
+        return $account->fresh();
+    }
+
+    /**
+     * Suspends the Marketplace account belonging to the given IAM account,
+     * if one exists. Marketplace accounts are opt-in, so a customer without
+     * one is a no-op here, not an error.
+     */
+    public static function suspendWithIamAccount(\NextDeveloper\IAM\Database\Models\Accounts $account): ?Accounts
+    {
+        $marketplaceAccount = Accounts::withoutGlobalScope(AuthorizationScope::class)
+            ->where('iam_account_id', $account->id)
+            ->first();
+
+        if (!$marketplaceAccount) {
+            return null;
+        }
+
+        return self::suspend($marketplaceAccount);
+    }
 }


### PR DESCRIPTION
## Summary
- Wires the Marketplace module into the CRM account-suspension flow (`SuspendAccountAndServices` in plusclouds.api.v4) by adding `AccountsService::suspendWithIamAccount()`.
- Disables `is_service_enabled` for the account tied to the given IAM account; no-op if the customer never had a Marketplace account (opt-in module).

🤖 Generated with [Claude Code](https://claude.com/claude-code)