### PR TITLE
Fix: explicit nullable parameter types (PHP 8.4 deprecation)

### DIFF
--- a/src/Authorization/Roles/MarketplaceAdminRole.php
+++ b/src/Authorization/Roles/MarketplaceAdminRole.php
@@ -33,7 +33,7 @@ class MarketplaceAdminRole extends AbstractRole implements IAuthorizationRole
 
     }
 
-    public function checkPrivileges(Users $users = null)
+    public function checkPrivileges(?Users $users = null)
     {
         //return UserHelper::hasRole(self::NAME, $users);
     }

--- a/src/Database/Filters/AccountsQueryFilter.php
+++ b/src/Database/Filters/AccountsQueryFilter.php
@@ -28,7 +28,7 @@ class AccountsQueryFilter extends AbstractQueryFilter
     {
         return $this->isServiceEnabled($value);
     }
-     
+
     public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
@@ -104,7 +104,7 @@ class AccountsQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 
 

--- a/src/Database/Filters/MarketsPerspectiveQueryFilter.php
+++ b/src/Database/Filters/MarketsPerspectiveQueryFilter.php
@@ -17,55 +17,55 @@ class MarketsPerspectiveQueryFilter extends AbstractQueryFilter
      * @var Builder
      */
     protected $builder;
-    
+
     public function name($value)
     {
         return $this->builder->where('name', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function description($value)
     {
         return $this->builder->where('description', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function domain($value)
     {
         return $this->builder->where('domain', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function currency($value)
     {
         return $this->builder->where('currency', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function language($value)
     {
         return $this->builder->where('language', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function country($value)
     {
         return $this->builder->where('country', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function maintainer($value)
     {
         return $this->builder->where('maintainer', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function responsible($value)
     {
         return $this->builder->where('responsible', 'ilike', '%' . $value . '%');
     }
 
-    
+
     public function productCount($value)
     {
         $operator = substr($value, 0, 1);
@@ -84,7 +84,7 @@ class MarketsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->productCount($value);
     }
-    
+
     public function isPublic($value)
     {
         return $this->builder->where('is_public', $value);
@@ -95,7 +95,7 @@ class MarketsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->isPublic($value);
     }
-     
+
     public function isActive($value)
     {
         return $this->builder->where('is_active', $value);
@@ -106,7 +106,7 @@ class MarketsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->isActive($value);
     }
-     
+
     public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
@@ -187,7 +187,7 @@ class MarketsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->commonDomain($value);
     }
-    
+
     public function commonCurrencyId($value)
     {
             $commonCurrency = \NextDeveloper\Commons\Database\Models\Currencies::where('uuid', $value)->first();
@@ -202,7 +202,7 @@ class MarketsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->commonCurrency($value);
     }
-    
+
     public function commonLanguageId($value)
     {
             $commonLanguage = \NextDeveloper\Commons\Database\Models\Languages::where('uuid', $value)->first();
@@ -217,7 +217,7 @@ class MarketsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->commonLanguage($value);
     }
-    
+
     public function commonCountryId($value)
     {
             $commonCountry = \NextDeveloper\Commons\Database\Models\Countries::where('uuid', $value)->first();
@@ -232,7 +232,7 @@ class MarketsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->commonCountry($value);
     }
-    
+
     public function iamAccountId($value)
     {
             $iamAccount = \NextDeveloper\IAM\Database\Models\Accounts::where('uuid', $value)->first();
@@ -242,7 +242,7 @@ class MarketsPerspectiveQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     public function iamUserId($value)
     {
             $iamUser = \NextDeveloper\IAM\Database\Models\Users::where('uuid', $value)->first();
@@ -252,7 +252,7 @@ class MarketsPerspectiveQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 
 

--- a/src/Database/Filters/MarketsQueryFilter.php
+++ b/src/Database/Filters/MarketsQueryFilter.php
@@ -17,19 +17,19 @@ class MarketsQueryFilter extends AbstractQueryFilter
      * @var Builder
      */
     protected $builder;
-    
+
     public function name($value)
     {
         return $this->builder->where('name', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function description($value)
     {
         return $this->builder->where('description', 'ilike', '%' . $value . '%');
     }
 
-    
+
     public function isPublic($value)
     {
         return $this->builder->where('is_public', $value);
@@ -40,7 +40,7 @@ class MarketsQueryFilter extends AbstractQueryFilter
     {
         return $this->isPublic($value);
     }
-     
+
     public function isActive($value)
     {
         return $this->builder->where('is_active', $value);
@@ -51,7 +51,7 @@ class MarketsQueryFilter extends AbstractQueryFilter
     {
         return $this->isActive($value);
     }
-     
+
     public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
@@ -132,7 +132,7 @@ class MarketsQueryFilter extends AbstractQueryFilter
     {
         return $this->commonDomain($value);
     }
-    
+
     public function commonCurrencyId($value)
     {
             $commonCurrency = \NextDeveloper\Commons\Database\Models\Currencies::where('uuid', $value)->first();
@@ -147,7 +147,7 @@ class MarketsQueryFilter extends AbstractQueryFilter
     {
         return $this->commonCurrency($value);
     }
-    
+
     public function commonLanguageId($value)
     {
             $commonLanguage = \NextDeveloper\Commons\Database\Models\Languages::where('uuid', $value)->first();
@@ -162,7 +162,7 @@ class MarketsQueryFilter extends AbstractQueryFilter
     {
         return $this->commonLanguage($value);
     }
-    
+
     public function commonCountryId($value)
     {
             $commonCountry = \NextDeveloper\Commons\Database\Models\Countries::where('uuid', $value)->first();
@@ -177,7 +177,7 @@ class MarketsQueryFilter extends AbstractQueryFilter
     {
         return $this->commonCountry($value);
     }
-    
+
     public function iamUserId($value)
     {
             $iamUser = \NextDeveloper\IAM\Database\Models\Users::where('uuid', $value)->first();
@@ -187,7 +187,7 @@ class MarketsQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     public function iamAccountId($value)
     {
             $iamAccount = \NextDeveloper\IAM\Database\Models\Accounts::where('uuid', $value)->first();
@@ -197,7 +197,7 @@ class MarketsQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 
 

--- a/src/Database/Filters/OrderItemsPerspectiveQueryFilter.php
+++ b/src/Database/Filters/OrderItemsPerspectiveQueryFilter.php
@@ -17,13 +17,13 @@ class OrderItemsPerspectiveQueryFilter extends AbstractQueryFilter
      * @var Builder
      */
     protected $builder;
-    
+
     public function name($value)
     {
         return $this->builder->where('name', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function specialInstructions($value)
     {
         return $this->builder->where('special_instructions', 'ilike', '%' . $value . '%');
@@ -34,13 +34,13 @@ class OrderItemsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->specialInstructions($value);
     }
-        
+
     public function sku($value)
     {
         return $this->builder->where('sku', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function deliveryMethod($value)
     {
         return $this->builder->where('delivery_method', 'ilike', '%' . $value . '%');
@@ -51,7 +51,7 @@ class OrderItemsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->deliveryMethod($value);
     }
-        
+
     public function productName($value)
     {
         return $this->builder->where('product_name', 'ilike', '%' . $value . '%');
@@ -62,7 +62,7 @@ class OrderItemsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->productName($value);
     }
-        
+
     public function providerName($value)
     {
         return $this->builder->where('provider_name', 'ilike', '%' . $value . '%');
@@ -73,7 +73,7 @@ class OrderItemsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->providerName($value);
     }
-        
+
     public function orderNumber($value)
     {
         return $this->builder->where('order_number', 'ilike', '%' . $value . '%');
@@ -84,13 +84,13 @@ class OrderItemsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->orderNumber($value);
     }
-        
+
     public function status($value)
     {
         return $this->builder->where('status', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function customerNote($value)
     {
         return $this->builder->where('customer_note', 'ilike', '%' . $value . '%');
@@ -101,7 +101,7 @@ class OrderItemsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->customerNote($value);
     }
-    
+
     public function quantity($value)
     {
         $operator = substr($value, 0, 1);
@@ -115,7 +115,7 @@ class OrderItemsPerspectiveQueryFilter extends AbstractQueryFilter
         return $this->builder->where('quantity', $operator, $value);
     }
 
-    
+
     public function quantityInInventory($value)
     {
         $operator = substr($value, 0, 1);
@@ -134,7 +134,7 @@ class OrderItemsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->quantityInInventory($value);
     }
-    
+
     public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
@@ -259,7 +259,7 @@ class OrderItemsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->marketplaceOrder($value);
     }
-    
+
     public function marketplaceProductCatalogId($value)
     {
             $marketplaceProductCatalog = \NextDeveloper\Marketplace\Database\Models\ProductCatalogs::where('uuid', $value)->first();
@@ -274,7 +274,7 @@ class OrderItemsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->marketplaceProductCatalog($value);
     }
-    
+
     public function iamAccountId($value)
     {
             $iamAccount = \NextDeveloper\IAM\Database\Models\Accounts::where('uuid', $value)->first();
@@ -284,7 +284,7 @@ class OrderItemsPerspectiveQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     public function iamUserId($value)
     {
             $iamUser = \NextDeveloper\IAM\Database\Models\Users::where('uuid', $value)->first();
@@ -294,7 +294,7 @@ class OrderItemsPerspectiveQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 
 

--- a/src/Database/Filters/OrderItemsQueryFilter.php
+++ b/src/Database/Filters/OrderItemsQueryFilter.php
@@ -17,7 +17,7 @@ class OrderItemsQueryFilter extends AbstractQueryFilter
      * @var Builder
      */
     protected $builder;
-    
+
     public function specialInstructions($value)
     {
         return $this->builder->where('special_instructions', 'ilike', '%' . $value . '%');
@@ -28,7 +28,7 @@ class OrderItemsQueryFilter extends AbstractQueryFilter
     {
         return $this->specialInstructions($value);
     }
-    
+
     public function quantity($value)
     {
         $operator = substr($value, 0, 1);
@@ -42,7 +42,7 @@ class OrderItemsQueryFilter extends AbstractQueryFilter
         return $this->builder->where('quantity', $operator, $value);
     }
 
-    
+
     public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
@@ -123,7 +123,7 @@ class OrderItemsQueryFilter extends AbstractQueryFilter
     {
         return $this->marketplaceOrder($value);
     }
-    
+
     public function marketplaceProductCatalogId($value)
     {
             $marketplaceProductCatalog = \NextDeveloper\Marketplace\Database\Models\ProductCatalogs::where('uuid', $value)->first();
@@ -138,7 +138,7 @@ class OrderItemsQueryFilter extends AbstractQueryFilter
     {
         return $this->marketplaceProductCatalog($value);
     }
-    
+
     public function iamAccountId($value)
     {
             $iamAccount = \NextDeveloper\IAM\Database\Models\Accounts::where('uuid', $value)->first();
@@ -148,7 +148,7 @@ class OrderItemsQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     public function iamUserId($value)
     {
             $iamUser = \NextDeveloper\IAM\Database\Models\Users::where('uuid', $value)->first();
@@ -158,7 +158,7 @@ class OrderItemsQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 
 

--- a/src/Database/Filters/OrderStatusHistoriesQueryFilter.php
+++ b/src/Database/Filters/OrderStatusHistoriesQueryFilter.php
@@ -17,7 +17,7 @@ class OrderStatusHistoriesQueryFilter extends AbstractQueryFilter
      * @var Builder
      */
     protected $builder;
-    
+
     public function oldStatus($value)
     {
         return $this->builder->where('old_status', 'ilike', '%' . $value . '%');
@@ -28,7 +28,7 @@ class OrderStatusHistoriesQueryFilter extends AbstractQueryFilter
     {
         return $this->oldStatus($value);
     }
-        
+
     public function newStatus($value)
     {
         return $this->builder->where('new_status', 'ilike', '%' . $value . '%');
@@ -39,13 +39,13 @@ class OrderStatusHistoriesQueryFilter extends AbstractQueryFilter
     {
         return $this->newStatus($value);
     }
-        
+
     public function notes($value)
     {
         return $this->builder->where('notes', 'ilike', '%' . $value . '%');
     }
 
-    
+
     public function changedAtStart($date)
     {
         return $this->builder->where('changed_at', '>=', $date);
@@ -148,7 +148,7 @@ class OrderStatusHistoriesQueryFilter extends AbstractQueryFilter
     {
         return $this->marketplaceOrder($value);
     }
-    
+
     public function iamAccountId($value)
     {
             $iamAccount = \NextDeveloper\IAM\Database\Models\Accounts::where('uuid', $value)->first();
@@ -158,7 +158,7 @@ class OrderStatusHistoriesQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     public function iamUserId($value)
     {
             $iamUser = \NextDeveloper\IAM\Database\Models\Users::where('uuid', $value)->first();
@@ -168,7 +168,7 @@ class OrderStatusHistoriesQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 
 

--- a/src/Database/Filters/OrdersQueryFilter.php
+++ b/src/Database/Filters/OrdersQueryFilter.php
@@ -37,7 +37,7 @@ class OrdersQueryFilter extends AbstractQueryFilter
      * @var Builder
      */
     protected $builder;
-    
+
     public function externalOrderId($value)
     {
         return $this->builder->where('external_order_id', 'ilike', '%' . $value . '%');
@@ -48,7 +48,7 @@ class OrdersQueryFilter extends AbstractQueryFilter
     {
         return $this->externalOrderId($value);
     }
-        
+
     public function externalOrderNumber($value)
     {
         return $this->builder->where('external_order_number', 'ilike', '%' . $value . '%');
@@ -59,13 +59,13 @@ class OrdersQueryFilter extends AbstractQueryFilter
     {
         return $this->externalOrderNumber($value);
     }
-        
+
     public function status($value)
     {
         return $this->builder->where('status', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function orderType($value)
     {
         return $this->builder->where('order_type', 'ilike', '%' . $value . '%');
@@ -76,7 +76,7 @@ class OrdersQueryFilter extends AbstractQueryFilter
     {
         return $this->orderType($value);
     }
-        
+
     public function deliveryMethod($value)
     {
         return $this->builder->where('delivery_method', 'ilike', '%' . $value . '%');
@@ -87,7 +87,7 @@ class OrdersQueryFilter extends AbstractQueryFilter
     {
         return $this->deliveryMethod($value);
     }
-        
+
     public function syncErrorMessage($value)
     {
         return $this->builder->where('sync_error_message', 'ilike', '%' . $value . '%');
@@ -98,7 +98,7 @@ class OrdersQueryFilter extends AbstractQueryFilter
     {
         return $this->syncErrorMessage($value);
     }
-        
+
     public function customerNote($value)
     {
         return $this->builder->where('customer_note', 'ilike', '%' . $value . '%');
@@ -109,7 +109,7 @@ class OrdersQueryFilter extends AbstractQueryFilter
     {
         return $this->customerNote($value);
     }
-        
+
     public function externalLineId($value)
     {
         return $this->builder->where('external_line_id', 'ilike', '%' . $value . '%');
@@ -120,13 +120,13 @@ class OrdersQueryFilter extends AbstractQueryFilter
     {
         return $this->externalLineId($value);
     }
-        
+
     public function provider($value)
     {
         return $this->builder->where('provider', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function orderNo($value)
     {
         return $this->builder->where('order_no', 'ilike', '%' . $value . '%');
@@ -137,7 +137,7 @@ class OrdersQueryFilter extends AbstractQueryFilter
     {
         return $this->orderNo($value);
     }
-    
+
     public function orderedAtStart($date)
     {
         return $this->builder->where('ordered_at', '>=', $date);
@@ -394,7 +394,7 @@ class OrdersQueryFilter extends AbstractQueryFilter
     {
         return $this->marketplaceMarket($value);
     }
-    
+
     public function marketplaceProviderId($value)
     {
             $marketplaceProvider = \NextDeveloper\Marketplace\Database\Models\Providers::where('uuid', $value)->first();
@@ -409,7 +409,7 @@ class OrdersQueryFilter extends AbstractQueryFilter
     {
         return $this->marketplaceProvider($value);
     }
-    
+
     public function marketplaceProductId($value)
     {
             $marketplaceProduct = \NextDeveloper\Marketplace\Database\Models\Products::where('uuid', $value)->first();
@@ -424,7 +424,7 @@ class OrdersQueryFilter extends AbstractQueryFilter
     {
         return $this->marketplaceProduct($value);
     }
-    
+
     public function iamAccountId($value)
     {
             $iamAccount = \NextDeveloper\IAM\Database\Models\Accounts::where('uuid', $value)->first();
@@ -434,7 +434,7 @@ class OrdersQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     public function iamUserId($value)
     {
             $iamUser = \NextDeveloper\IAM\Database\Models\Users::where('uuid', $value)->first();
@@ -444,7 +444,7 @@ class OrdersQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 
 

--- a/src/Database/Filters/ProductCatalogMappingsQueryFilter.php
+++ b/src/Database/Filters/ProductCatalogMappingsQueryFilter.php
@@ -17,7 +17,7 @@ class ProductCatalogMappingsQueryFilter extends AbstractQueryFilter
      * @var Builder
      */
     protected $builder;
-    
+
     public function externalCatalogId($value)
     {
         return $this->builder->where('external_catalog_id', 'ilike', '%' . $value . '%');
@@ -28,7 +28,7 @@ class ProductCatalogMappingsQueryFilter extends AbstractQueryFilter
     {
         return $this->externalCatalogId($value);
     }
-    
+
     public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
@@ -109,7 +109,7 @@ class ProductCatalogMappingsQueryFilter extends AbstractQueryFilter
     {
         return $this->marketplaceProductCatalog($value);
     }
-    
+
     public function marketplaceProviderId($value)
     {
             $marketplaceProvider = \NextDeveloper\Marketplace\Database\Models\Providers::where('uuid', $value)->first();
@@ -124,7 +124,7 @@ class ProductCatalogMappingsQueryFilter extends AbstractQueryFilter
     {
         return $this->marketplaceProvider($value);
     }
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 
 

--- a/src/Database/Filters/ProductCatalogsPerspectiveQueryFilter.php
+++ b/src/Database/Filters/ProductCatalogsPerspectiveQueryFilter.php
@@ -37,25 +37,25 @@ class ProductCatalogsPerspectiveQueryFilter extends AbstractQueryFilter
      * @var Builder
      */
     protected $builder;
-    
+
     public function name($value)
     {
         return $this->builder->where('name', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function sku($value)
     {
         return $this->builder->where('sku', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function product($value)
     {
         return $this->builder->where('product', 'ilike', '%' . $value . '%');
     }
 
-    
+
     public function quantityInInventory($value)
     {
         $operator = substr($value, 0, 1);
@@ -74,7 +74,7 @@ class ProductCatalogsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->quantityInInventory($value);
     }
-    
+
     public function trialDate($value)
     {
         $operator = substr($value, 0, 1);
@@ -93,7 +93,7 @@ class ProductCatalogsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->trialDate($value);
     }
-    
+
     public function isPublic($value)
     {
         return $this->builder->where('is_public', $value);
@@ -104,7 +104,7 @@ class ProductCatalogsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->isPublic($value);
     }
-     
+
     public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
@@ -185,7 +185,7 @@ class ProductCatalogsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->marketplaceProduct($value);
     }
-    
+
     public function iamAccountId($value)
     {
             $iamAccount = \NextDeveloper\IAM\Database\Models\Accounts::where('uuid', $value)->first();
@@ -195,7 +195,7 @@ class ProductCatalogsPerspectiveQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     public function iamUserId($value)
     {
             $iamUser = \NextDeveloper\IAM\Database\Models\Users::where('uuid', $value)->first();
@@ -205,7 +205,7 @@ class ProductCatalogsPerspectiveQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 
 

--- a/src/Database/Filters/ProductCatalogsQueryFilter.php
+++ b/src/Database/Filters/ProductCatalogsQueryFilter.php
@@ -37,25 +37,25 @@ class ProductCatalogsQueryFilter extends AbstractQueryFilter
      * @var Builder
      */
     protected $builder;
-    
+
     public function name($value)
     {
         return $this->builder->where('name', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function agreement($value)
     {
         return $this->builder->where('agreement', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function sku($value)
     {
         return $this->builder->where('sku', 'ilike', '%' . $value . '%');
     }
 
-    
+
     public function quantityInInventory($value)
     {
         $operator = substr($value, 0, 1);
@@ -74,7 +74,7 @@ class ProductCatalogsQueryFilter extends AbstractQueryFilter
     {
         return $this->quantityInInventory($value);
     }
-    
+
     public function trialDate($value)
     {
         $operator = substr($value, 0, 1);
@@ -93,7 +93,7 @@ class ProductCatalogsQueryFilter extends AbstractQueryFilter
     {
         return $this->trialDate($value);
     }
-    
+
     public function isPublic($value)
     {
         return $this->builder->where('is_public', $value);
@@ -104,7 +104,7 @@ class ProductCatalogsQueryFilter extends AbstractQueryFilter
     {
         return $this->isPublic($value);
     }
-     
+
     public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
@@ -185,7 +185,7 @@ class ProductCatalogsQueryFilter extends AbstractQueryFilter
     {
         return $this->marketplaceProduct($value);
     }
-    
+
     public function iamAccountId($value)
     {
             $iamAccount = \NextDeveloper\IAM\Database\Models\Accounts::where('uuid', $value)->first();
@@ -195,7 +195,7 @@ class ProductCatalogsQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     public function iamUserId($value)
     {
             $iamUser = \NextDeveloper\IAM\Database\Models\Users::where('uuid', $value)->first();
@@ -205,7 +205,7 @@ class ProductCatalogsQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     public function commonCurrencyId($value)
     {
             $commonCurrency = \NextDeveloper\Commons\Database\Models\Currencies::where('uuid', $value)->first();
@@ -220,7 +220,7 @@ class ProductCatalogsQueryFilter extends AbstractQueryFilter
     {
         return $this->commonCurrency($value);
     }
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 
 

--- a/src/Database/Filters/ProductMappingsQueryFilter.php
+++ b/src/Database/Filters/ProductMappingsQueryFilter.php
@@ -17,7 +17,7 @@ class ProductMappingsQueryFilter extends AbstractQueryFilter
      * @var Builder
      */
     protected $builder;
-    
+
     public function externalProductId($value)
     {
         return $this->builder->where('external_product_id', 'ilike', '%' . $value . '%');
@@ -28,7 +28,7 @@ class ProductMappingsQueryFilter extends AbstractQueryFilter
     {
         return $this->externalProductId($value);
     }
-    
+
     public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
@@ -109,7 +109,7 @@ class ProductMappingsQueryFilter extends AbstractQueryFilter
     {
         return $this->marketplaceProduct($value);
     }
-    
+
     public function marketplaceProviderId($value)
     {
             $marketplaceProvider = \NextDeveloper\Marketplace\Database\Models\Providers::where('uuid', $value)->first();
@@ -124,7 +124,7 @@ class ProductMappingsQueryFilter extends AbstractQueryFilter
     {
         return $this->marketplaceProvider($value);
     }
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 
 

--- a/src/Database/Filters/ProductsPerspectiveQueryFilter.php
+++ b/src/Database/Filters/ProductsPerspectiveQueryFilter.php
@@ -37,37 +37,37 @@ class ProductsPerspectiveQueryFilter extends AbstractQueryFilter
      * @var Builder
      */
     protected $builder;
-    
+
     public function name($value)
     {
         return $this->builder->where('name', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function description($value)
     {
         return $this->builder->where('description', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function content($value)
     {
         return $this->builder->where('content', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function slug($value)
     {
         return $this->builder->where('slug', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function version($value)
     {
         return $this->builder->where('version', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function salesPitch($value)
     {
         return $this->builder->where('sales_pitch', 'ilike', '%' . $value . '%');
@@ -78,25 +78,25 @@ class ProductsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->salesPitch($value);
     }
-        
+
     public function category($value)
     {
         return $this->builder->where('category', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function marketplace($value)
     {
         return $this->builder->where('marketplace', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function maintainer($value)
     {
         return $this->builder->where('maintainer', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function aboutMaintainer($value)
     {
         return $this->builder->where('about_maintainer', 'ilike', '%' . $value . '%');
@@ -107,13 +107,13 @@ class ProductsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->aboutMaintainer($value);
     }
-        
+
     public function responsible($value)
     {
         return $this->builder->where('responsible', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function currencyCode($value)
     {
         return $this->builder->where('currency_code', 'ilike', '%' . $value . '%');
@@ -124,7 +124,7 @@ class ProductsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->currencyCode($value);
     }
-        
+
     public function partnerMeetingLink($value)
     {
         return $this->builder->where('partner_meeting_link', 'ilike', '%' . $value . '%');
@@ -135,7 +135,7 @@ class ProductsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->partnerMeetingLink($value);
     }
-        
+
     public function refundPolicy($value)
     {
         return $this->builder->where('refund_policy', 'ilike', '%' . $value . '%');
@@ -146,7 +146,7 @@ class ProductsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->refundPolicy($value);
     }
-        
+
     public function afterSalesIntroduction($value)
     {
         return $this->builder->where('after_sales_introduction', 'ilike', '%' . $value . '%');
@@ -157,7 +157,7 @@ class ProductsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->afterSalesIntroduction($value);
     }
-        
+
     public function supportContent($value)
     {
         return $this->builder->where('support_content', 'ilike', '%' . $value . '%');
@@ -168,13 +168,13 @@ class ProductsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->supportContent($value);
     }
-        
+
     public function eula($value)
     {
         return $this->builder->where('eula', 'ilike', '%' . $value . '%');
     }
 
-    
+
     public function productCatalogCount($value)
     {
         $operator = substr($value, 0, 1);
@@ -193,7 +193,7 @@ class ProductsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->productCatalogCount($value);
     }
-    
+
     public function isService($value)
     {
         return $this->builder->where('is_service', $value);
@@ -204,7 +204,7 @@ class ProductsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->isService($value);
     }
-     
+
     public function isInMaintenance($value)
     {
         return $this->builder->where('is_in_maintenance', $value);
@@ -215,7 +215,7 @@ class ProductsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->isInMaintenance($value);
     }
-     
+
     public function isPublic($value)
     {
         return $this->builder->where('is_public', $value);
@@ -226,7 +226,7 @@ class ProductsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->isPublic($value);
     }
-     
+
     public function isInvisible($value)
     {
         return $this->builder->where('is_invisible', $value);
@@ -237,7 +237,7 @@ class ProductsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->isInvisible($value);
     }
-     
+
     public function isActive($value)
     {
         return $this->builder->where('is_active', $value);
@@ -248,7 +248,7 @@ class ProductsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->isActive($value);
     }
-     
+
     public function isApproved($value)
     {
         return $this->builder->where('is_approved', $value);
@@ -259,7 +259,7 @@ class ProductsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->isApproved($value);
     }
-     
+
     public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
@@ -340,7 +340,7 @@ class ProductsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->commonCategory($value);
     }
-    
+
     public function marketplaceMarketId($value)
     {
             $marketplaceMarket = \NextDeveloper\Marketplace\Database\Models\Markets::where('uuid', $value)->first();
@@ -355,7 +355,7 @@ class ProductsPerspectiveQueryFilter extends AbstractQueryFilter
     {
         return $this->marketplaceMarket($value);
     }
-    
+
     public function iamAccountId($value)
     {
             $iamAccount = \NextDeveloper\IAM\Database\Models\Accounts::where('uuid', $value)->first();
@@ -365,7 +365,7 @@ class ProductsPerspectiveQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     public function iamUserId($value)
     {
             $iamUser = \NextDeveloper\IAM\Database\Models\Users::where('uuid', $value)->first();
@@ -375,7 +375,7 @@ class ProductsPerspectiveQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 
 

--- a/src/Database/Filters/ProductsQueryFilter.php
+++ b/src/Database/Filters/ProductsQueryFilter.php
@@ -37,25 +37,25 @@ class ProductsQueryFilter extends AbstractQueryFilter
      * @var Builder
      */
     protected $builder;
-    
+
     public function name($value)
     {
         return $this->builder->where('name', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function description($value)
     {
         return $this->builder->where('description', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function content($value)
     {
         return $this->builder->where('content', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function afterSalesIntroduction($value)
     {
         return $this->builder->where('after_sales_introduction', 'ilike', '%' . $value . '%');
@@ -66,7 +66,7 @@ class ProductsQueryFilter extends AbstractQueryFilter
     {
         return $this->afterSalesIntroduction($value);
     }
-        
+
     public function supportContent($value)
     {
         return $this->builder->where('support_content', 'ilike', '%' . $value . '%');
@@ -77,7 +77,7 @@ class ProductsQueryFilter extends AbstractQueryFilter
     {
         return $this->supportContent($value);
     }
-        
+
     public function refundPolicy($value)
     {
         return $this->builder->where('refund_policy', 'ilike', '%' . $value . '%');
@@ -88,25 +88,25 @@ class ProductsQueryFilter extends AbstractQueryFilter
     {
         return $this->refundPolicy($value);
     }
-        
+
     public function eula($value)
     {
         return $this->builder->where('eula', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function slug($value)
     {
         return $this->builder->where('slug', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function version($value)
     {
         return $this->builder->where('version', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function salesPitch($value)
     {
         return $this->builder->where('sales_pitch', 'ilike', '%' . $value . '%');
@@ -117,7 +117,7 @@ class ProductsQueryFilter extends AbstractQueryFilter
     {
         return $this->salesPitch($value);
     }
-    
+
     public function isInMaintenance($value)
     {
         return $this->builder->where('is_in_maintenance', $value);
@@ -128,7 +128,7 @@ class ProductsQueryFilter extends AbstractQueryFilter
     {
         return $this->isInMaintenance($value);
     }
-     
+
     public function isPublic($value)
     {
         return $this->builder->where('is_public', $value);
@@ -139,7 +139,7 @@ class ProductsQueryFilter extends AbstractQueryFilter
     {
         return $this->isPublic($value);
     }
-     
+
     public function isInvisible($value)
     {
         return $this->builder->where('is_invisible', $value);
@@ -150,7 +150,7 @@ class ProductsQueryFilter extends AbstractQueryFilter
     {
         return $this->isInvisible($value);
     }
-     
+
     public function isActive($value)
     {
         return $this->builder->where('is_active', $value);
@@ -161,7 +161,7 @@ class ProductsQueryFilter extends AbstractQueryFilter
     {
         return $this->isActive($value);
     }
-     
+
     public function isService($value)
     {
         return $this->builder->where('is_service', $value);
@@ -172,7 +172,7 @@ class ProductsQueryFilter extends AbstractQueryFilter
     {
         return $this->isService($value);
     }
-     
+
     public function isApproved($value)
     {
         return $this->builder->where('is_approved', $value);
@@ -183,7 +183,7 @@ class ProductsQueryFilter extends AbstractQueryFilter
     {
         return $this->isApproved($value);
     }
-     
+
     public function isAdditionalProduct($value)
     {
         return $this->builder->where('is_additional_product', $value);
@@ -194,7 +194,7 @@ class ProductsQueryFilter extends AbstractQueryFilter
     {
         return $this->isAdditionalProduct($value);
     }
-     
+
     public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
@@ -275,7 +275,7 @@ class ProductsQueryFilter extends AbstractQueryFilter
     {
         return $this->commonCategory($value);
     }
-    
+
     public function iamAccountId($value)
     {
             $iamAccount = \NextDeveloper\IAM\Database\Models\Accounts::where('uuid', $value)->first();
@@ -285,7 +285,7 @@ class ProductsQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     public function iamUserId($value)
     {
             $iamUser = \NextDeveloper\IAM\Database\Models\Users::where('uuid', $value)->first();
@@ -295,7 +295,7 @@ class ProductsQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     public function marketplaceMarketId($value)
     {
             $marketplaceMarket = \NextDeveloper\Marketplace\Database\Models\Markets::where('uuid', $value)->first();
@@ -310,7 +310,7 @@ class ProductsQueryFilter extends AbstractQueryFilter
     {
         return $this->marketplaceMarket($value);
     }
-    
+
     public function marketplaceProviderId($value)
     {
             $marketplaceProvider = \NextDeveloper\Marketplace\Database\Models\Providers::where('uuid', $value)->first();
@@ -325,7 +325,7 @@ class ProductsQueryFilter extends AbstractQueryFilter
     {
         return $this->marketplaceProvider($value);
     }
-    
+
     public function parentMarketplaceProductId($value)
     {
             $parentMarketplaceProduct = \NextDeveloper\Marketplace\Database\Models\Products::where('uuid', $value)->first();
@@ -340,7 +340,7 @@ class ProductsQueryFilter extends AbstractQueryFilter
     {
         return $this->parentMarketplaceProduct($value);
     }
-    
+
     public function metadata($value)
     {
         return $this->builder->whereRaw("metadata @> ?::jsonb", [json_encode($value)]);

--- a/src/Database/Filters/ProvidersQueryFilter.php
+++ b/src/Database/Filters/ProvidersQueryFilter.php
@@ -17,37 +17,37 @@ class ProvidersQueryFilter extends AbstractQueryFilter
      * @var Builder
      */
     protected $builder;
-    
+
     public function name($value)
     {
         return $this->builder->where('name', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function description($value)
     {
         return $this->builder->where('description', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function action($value)
     {
         return $this->builder->where('action', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function url($value)
     {
         return $this->builder->where('url', 'ilike', '%' . $value . '%');
     }
 
-        
+
     public function adapter($value)
     {
         return $this->builder->where('adapter', 'ilike', '%' . $value . '%');
     }
 
-    
+
     public function isActive($value)
     {
         return $this->builder->where('is_active', $value);
@@ -58,7 +58,7 @@ class ProvidersQueryFilter extends AbstractQueryFilter
     {
         return $this->isActive($value);
     }
-     
+
     public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
@@ -139,7 +139,7 @@ class ProvidersQueryFilter extends AbstractQueryFilter
     {
         return $this->marketplaceMarket($value);
     }
-    
+
     public function iamAccountId($value)
     {
             $iamAccount = \NextDeveloper\IAM\Database\Models\Accounts::where('uuid', $value)->first();
@@ -149,7 +149,7 @@ class ProvidersQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     public function iamUserId($value)
     {
             $iamUser = \NextDeveloper\IAM\Database\Models\Users::where('uuid', $value)->first();
@@ -159,7 +159,7 @@ class ProvidersQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 
 

--- a/src/Database/Filters/StatusMappingsQueryFilter.php
+++ b/src/Database/Filters/StatusMappingsQueryFilter.php
@@ -17,7 +17,7 @@ class StatusMappingsQueryFilter extends AbstractQueryFilter
      * @var Builder
      */
     protected $builder;
-    
+
     public function externalStatus($value)
     {
         return $this->builder->where('external_status', 'ilike', '%' . $value . '%');
@@ -28,7 +28,7 @@ class StatusMappingsQueryFilter extends AbstractQueryFilter
     {
         return $this->externalStatus($value);
     }
-        
+
     public function normalizedStatus($value)
     {
         return $this->builder->where('normalized_status', 'ilike', '%' . $value . '%');
@@ -39,13 +39,13 @@ class StatusMappingsQueryFilter extends AbstractQueryFilter
     {
         return $this->normalizedStatus($value);
     }
-        
+
     public function description($value)
     {
         return $this->builder->where('description', 'ilike', '%' . $value . '%');
     }
 
-    
+
     public function createdAtStart($date)
     {
         return $this->builder->where('created_at', '>=', $date);
@@ -82,7 +82,7 @@ class StatusMappingsQueryFilter extends AbstractQueryFilter
     {
         return $this->marketplaceProvider($value);
     }
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 
 

--- a/src/Database/Filters/SubscriptionsQueryFilter.php
+++ b/src/Database/Filters/SubscriptionsQueryFilter.php
@@ -48,7 +48,7 @@ class SubscriptionsQueryFilter extends AbstractQueryFilter
     {
         return $this->isValid($value);
     }
-     
+
     public function subscriptionStartsAtStart($date)
     {
         return $this->builder->where('subscription_starts_at', '>=', $date);
@@ -173,7 +173,7 @@ class SubscriptionsQueryFilter extends AbstractQueryFilter
     {
         return $this->marketplaceProductCatalog($value);
     }
-    
+
     public function iamAccountId($value)
     {
             $iamAccount = \NextDeveloper\IAM\Database\Models\Accounts::where('uuid', $value)->first();
@@ -183,7 +183,7 @@ class SubscriptionsQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     public function iamUserId($value)
     {
             $iamUser = \NextDeveloper\IAM\Database\Models\Users::where('uuid', $value)->first();
@@ -193,7 +193,7 @@ class SubscriptionsQueryFilter extends AbstractQueryFilter
         }
     }
 
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 
 

--- a/src/Database/Models/Accounts.php
+++ b/src/Database/Models/Accounts.php
@@ -134,7 +134,7 @@ class Accounts extends Model
     {
         return $this->belongsTo(\NextDeveloper\IAM\Database\Models\Accounts::class);
     }
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 
 

--- a/src/Database/Models/Markets.php
+++ b/src/Database/Models/Markets.php
@@ -157,12 +157,12 @@ class Markets extends Model
     {
         return $this->belongsTo(\NextDeveloper\IAM\Database\Models\Accounts::class);
     }
-    
+
     public function users() : \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return $this->belongsTo(\NextDeveloper\IAM\Database\Models\Users::class);
     }
-    
+
     public function products() : \Illuminate\Database\Eloquent\Relations\HasMany
     {
         return $this->hasMany(\NextDeveloper\Marketplace\Database\Models\Products::class);

--- a/src/Database/Models/OrderItems.php
+++ b/src/Database/Models/OrderItems.php
@@ -155,12 +155,12 @@ class OrderItems extends Model
     {
         return $this->belongsTo(\NextDeveloper\Marketplace\Database\Models\Orders::class);
     }
-    
+
     public function productCatalogs() : \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return $this->belongsTo(\NextDeveloper\Marketplace\Database\Models\ProductCatalogs::class);
     }
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 
 

--- a/src/Database/Models/OrderStatusHistories.php
+++ b/src/Database/Models/OrderStatusHistories.php
@@ -149,17 +149,17 @@ class OrderStatusHistories extends Model
     {
         return $this->belongsTo(\NextDeveloper\Marketplace\Database\Models\Orders::class);
     }
-    
+
     public function accounts() : \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return $this->belongsTo(\NextDeveloper\IAM\Database\Models\Accounts::class);
     }
-    
+
     public function users() : \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return $this->belongsTo(\NextDeveloper\IAM\Database\Models\Users::class);
     }
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 
 

--- a/src/Database/Models/Orders.php
+++ b/src/Database/Models/Orders.php
@@ -231,27 +231,27 @@ class Orders extends Model
     {
         return $this->belongsTo(\NextDeveloper\Marketplace\Database\Models\Markets::class);
     }
-    
+
     public function providers() : \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return $this->belongsTo(\NextDeveloper\Marketplace\Database\Models\Providers::class);
     }
-    
+
     public function products() : \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return $this->belongsTo(\NextDeveloper\Marketplace\Database\Models\Products::class);
     }
-    
+
     public function accounts() : \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return $this->belongsTo(\NextDeveloper\IAM\Database\Models\Accounts::class);
     }
-    
+
     public function users() : \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return $this->belongsTo(\NextDeveloper\IAM\Database\Models\Users::class);
     }
-    
+
     public function orderItems() : \Illuminate\Database\Eloquent\Relations\HasMany
     {
         return $this->hasMany(\NextDeveloper\Marketplace\Database\Models\OrderItems::class);

--- a/src/Database/Models/ProductCatalogMappings.php
+++ b/src/Database/Models/ProductCatalogMappings.php
@@ -138,12 +138,12 @@ class ProductCatalogMappings extends Model
     {
         return $this->belongsTo(\NextDeveloper\Marketplace\Database\Models\Providers::class);
     }
-    
+
     public function productCatalogs() : \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return $this->belongsTo(\NextDeveloper\Marketplace\Database\Models\ProductCatalogs::class);
     }
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 
 

--- a/src/Database/Models/ProductCatalogs.php
+++ b/src/Database/Models/ProductCatalogs.php
@@ -168,7 +168,7 @@ class ProductCatalogs extends Model
     {
         return $this->belongsTo(\NextDeveloper\Marketplace\Database\Models\Products::class);
     }
-    
+
     public function subscriptions() : \Illuminate\Database\Eloquent\Relations\HasMany
     {
         return $this->hasMany(\NextDeveloper\Marketplace\Database\Models\Subscriptions::class);

--- a/src/Database/Models/ProductMappings.php
+++ b/src/Database/Models/ProductMappings.php
@@ -138,12 +138,12 @@ class ProductMappings extends Model
     {
         return $this->belongsTo(\NextDeveloper\Marketplace\Database\Models\Products::class);
     }
-    
+
     public function providers() : \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return $this->belongsTo(\NextDeveloper\Marketplace\Database\Models\Providers::class);
     }
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 
 

--- a/src/Database/Models/Products.php
+++ b/src/Database/Models/Products.php
@@ -217,27 +217,27 @@ class Products extends Model
     {
         return $this->belongsTo(\NextDeveloper\Marketplace\Database\Models\Markets::class);
     }
-    
+
     public function categories() : \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return $this->belongsTo(\NextDeveloper\Commons\Database\Models\Categories::class);
     }
-    
+
     public function accounts() : \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return $this->belongsTo(\NextDeveloper\IAM\Database\Models\Accounts::class);
     }
-    
+
     public function users() : \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return $this->belongsTo(\NextDeveloper\IAM\Database\Models\Users::class);
     }
-    
+
     public function providers() : \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return $this->belongsTo(\NextDeveloper\Marketplace\Database\Models\Providers::class);
     }
-    
+
     public function orders() : \Illuminate\Database\Eloquent\Relations\HasMany
     {
         return $this->hasMany(\NextDeveloper\Marketplace\Database\Models\Orders::class);

--- a/src/Database/Models/Providers.php
+++ b/src/Database/Models/Providers.php
@@ -162,17 +162,17 @@ class Providers extends Model
     {
         return $this->belongsTo(\NextDeveloper\Marketplace\Database\Models\Markets::class);
     }
-    
+
     public function accounts() : \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return $this->belongsTo(\NextDeveloper\IAM\Database\Models\Accounts::class);
     }
-    
+
     public function users() : \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return $this->belongsTo(\NextDeveloper\IAM\Database\Models\Users::class);
     }
-    
+
     public function orders() : \Illuminate\Database\Eloquent\Relations\HasMany
     {
         return $this->hasMany(\NextDeveloper\Marketplace\Database\Models\Orders::class);

--- a/src/Database/Models/StatusMappings.php
+++ b/src/Database/Models/StatusMappings.php
@@ -132,7 +132,7 @@ class StatusMappings extends Model
     {
         return $this->belongsTo(\NextDeveloper\Marketplace\Database\Models\Providers::class);
     }
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 
 

--- a/src/Database/Models/Subscriptions.php
+++ b/src/Database/Models/Subscriptions.php
@@ -153,17 +153,17 @@ class Subscriptions extends Model
     {
         return $this->belongsTo(\NextDeveloper\Marketplace\Database\Models\ProductCatalogs::class);
     }
-    
+
     public function accounts() : \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return $this->belongsTo(\NextDeveloper\IAM\Database\Models\Accounts::class);
     }
-    
+
     public function users() : \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return $this->belongsTo(\NextDeveloper\IAM\Database\Models\Users::class);
     }
-    
+
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 
 

--- a/src/Events/MarketplaceProduct/MarketplaceProductCreatedEvent.php
+++ b/src/Events/MarketplaceProduct/MarketplaceProductCreatedEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductCreatedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceProduct $model = null) {
+    public function __construct(?MarketplaceProduct $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/MarketplaceProduct/MarketplaceProductCreatingEvent.php
+++ b/src/Events/MarketplaceProduct/MarketplaceProductCreatingEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductCreatingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceProduct $model = null) {
+    public function __construct(?MarketplaceProduct $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/MarketplaceProduct/MarketplaceProductDeletedEvent.php
+++ b/src/Events/MarketplaceProduct/MarketplaceProductDeletedEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductDeletedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceProduct $model = null) {
+    public function __construct(?MarketplaceProduct $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/MarketplaceProduct/MarketplaceProductDeletingEvent.php
+++ b/src/Events/MarketplaceProduct/MarketplaceProductDeletingEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductDeletingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceProduct $model = null) {
+    public function __construct(?MarketplaceProduct $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/MarketplaceProduct/MarketplaceProductRestoredEvent.php
+++ b/src/Events/MarketplaceProduct/MarketplaceProductRestoredEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductRestoredEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceProduct $model = null) {
+    public function __construct(?MarketplaceProduct $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/MarketplaceProduct/MarketplaceProductRestoringEvent.php
+++ b/src/Events/MarketplaceProduct/MarketplaceProductRestoringEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductRestoringEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceProduct $model = null) {
+    public function __construct(?MarketplaceProduct $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/MarketplaceProduct/MarketplaceProductRetrievedEvent.php
+++ b/src/Events/MarketplaceProduct/MarketplaceProductRetrievedEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductRetrievedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceProduct $model = null) {
+    public function __construct(?MarketplaceProduct $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/MarketplaceProduct/MarketplaceProductSavedEvent.php
+++ b/src/Events/MarketplaceProduct/MarketplaceProductSavedEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductSavedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceProduct $model = null) {
+    public function __construct(?MarketplaceProduct $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/MarketplaceProduct/MarketplaceProductSavingEvent.php
+++ b/src/Events/MarketplaceProduct/MarketplaceProductSavingEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductSavingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceProduct $model = null) {
+    public function __construct(?MarketplaceProduct $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/MarketplaceProduct/MarketplaceProductUpdatedEvent.php
+++ b/src/Events/MarketplaceProduct/MarketplaceProductUpdatedEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductUpdatedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceProduct $model = null) {
+    public function __construct(?MarketplaceProduct $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/MarketplaceProduct/MarketplaceProductUpdatingEvent.php
+++ b/src/Events/MarketplaceProduct/MarketplaceProductUpdatingEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductUpdatingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceProduct $model = null) {
+    public function __construct(?MarketplaceProduct $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/MarketplaceProductCatalog/MarketplaceProductCatalogCreatedEvent.php
+++ b/src/Events/MarketplaceProductCatalog/MarketplaceProductCatalogCreatedEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductCatalogCreatedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceProductCatalog $model = null) {
+    public function __construct(?MarketplaceProductCatalog $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/MarketplaceProductCatalog/MarketplaceProductCatalogCreatingEvent.php
+++ b/src/Events/MarketplaceProductCatalog/MarketplaceProductCatalogCreatingEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductCatalogCreatingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceProductCatalog $model = null) {
+    public function __construct(?MarketplaceProductCatalog $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/MarketplaceProductCatalog/MarketplaceProductCatalogDeletedEvent.php
+++ b/src/Events/MarketplaceProductCatalog/MarketplaceProductCatalogDeletedEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductCatalogDeletedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceProductCatalog $model = null) {
+    public function __construct(?MarketplaceProductCatalog $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/MarketplaceProductCatalog/MarketplaceProductCatalogDeletingEvent.php
+++ b/src/Events/MarketplaceProductCatalog/MarketplaceProductCatalogDeletingEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductCatalogDeletingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceProductCatalog $model = null) {
+    public function __construct(?MarketplaceProductCatalog $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/MarketplaceProductCatalog/MarketplaceProductCatalogRestoredEvent.php
+++ b/src/Events/MarketplaceProductCatalog/MarketplaceProductCatalogRestoredEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductCatalogRestoredEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceProductCatalog $model = null) {
+    public function __construct(?MarketplaceProductCatalog $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/MarketplaceProductCatalog/MarketplaceProductCatalogRestoringEvent.php
+++ b/src/Events/MarketplaceProductCatalog/MarketplaceProductCatalogRestoringEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductCatalogRestoringEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceProductCatalog $model = null) {
+    public function __construct(?MarketplaceProductCatalog $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/MarketplaceProductCatalog/MarketplaceProductCatalogRetrievedEvent.php
+++ b/src/Events/MarketplaceProductCatalog/MarketplaceProductCatalogRetrievedEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductCatalogRetrievedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceProductCatalog $model = null) {
+    public function __construct(?MarketplaceProductCatalog $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/MarketplaceProductCatalog/MarketplaceProductCatalogSavedEvent.php
+++ b/src/Events/MarketplaceProductCatalog/MarketplaceProductCatalogSavedEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductCatalogSavedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceProductCatalog $model = null) {
+    public function __construct(?MarketplaceProductCatalog $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/MarketplaceProductCatalog/MarketplaceProductCatalogSavingEvent.php
+++ b/src/Events/MarketplaceProductCatalog/MarketplaceProductCatalogSavingEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductCatalogSavingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceProductCatalog $model = null) {
+    public function __construct(?MarketplaceProductCatalog $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/MarketplaceProductCatalog/MarketplaceProductCatalogUpdatedEvent.php
+++ b/src/Events/MarketplaceProductCatalog/MarketplaceProductCatalogUpdatedEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductCatalogUpdatedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceProductCatalog $model = null) {
+    public function __construct(?MarketplaceProductCatalog $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/MarketplaceProductCatalog/MarketplaceProductCatalogUpdatingEvent.php
+++ b/src/Events/MarketplaceProductCatalog/MarketplaceProductCatalogUpdatingEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductCatalogUpdatingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceProductCatalog $model = null) {
+    public function __construct(?MarketplaceProductCatalog $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/MarketplaceSubscription/MarketplaceSubscriptionCreatedEvent.php
+++ b/src/Events/MarketplaceSubscription/MarketplaceSubscriptionCreatedEvent.php
@@ -23,7 +23,7 @@ class MarketplaceSubscriptionCreatedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceSubscription $model = null) {
+    public function __construct(?MarketplaceSubscription $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/MarketplaceSubscription/MarketplaceSubscriptionCreatingEvent.php
+++ b/src/Events/MarketplaceSubscription/MarketplaceSubscriptionCreatingEvent.php
@@ -23,7 +23,7 @@ class MarketplaceSubscriptionCreatingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceSubscription $model = null) {
+    public function __construct(?MarketplaceSubscription $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/MarketplaceSubscription/MarketplaceSubscriptionDeletedEvent.php
+++ b/src/Events/MarketplaceSubscription/MarketplaceSubscriptionDeletedEvent.php
@@ -23,7 +23,7 @@ class MarketplaceSubscriptionDeletedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceSubscription $model = null) {
+    public function __construct(?MarketplaceSubscription $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/MarketplaceSubscription/MarketplaceSubscriptionDeletingEvent.php
+++ b/src/Events/MarketplaceSubscription/MarketplaceSubscriptionDeletingEvent.php
@@ -23,7 +23,7 @@ class MarketplaceSubscriptionDeletingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceSubscription $model = null) {
+    public function __construct(?MarketplaceSubscription $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/MarketplaceSubscription/MarketplaceSubscriptionRestoredEvent.php
+++ b/src/Events/MarketplaceSubscription/MarketplaceSubscriptionRestoredEvent.php
@@ -23,7 +23,7 @@ class MarketplaceSubscriptionRestoredEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceSubscription $model = null) {
+    public function __construct(?MarketplaceSubscription $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/MarketplaceSubscription/MarketplaceSubscriptionRestoringEvent.php
+++ b/src/Events/MarketplaceSubscription/MarketplaceSubscriptionRestoringEvent.php
@@ -23,7 +23,7 @@ class MarketplaceSubscriptionRestoringEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceSubscription $model = null) {
+    public function __construct(?MarketplaceSubscription $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/MarketplaceSubscription/MarketplaceSubscriptionRetrievedEvent.php
+++ b/src/Events/MarketplaceSubscription/MarketplaceSubscriptionRetrievedEvent.php
@@ -23,7 +23,7 @@ class MarketplaceSubscriptionRetrievedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceSubscription $model = null) {
+    public function __construct(?MarketplaceSubscription $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/MarketplaceSubscription/MarketplaceSubscriptionSavedEvent.php
+++ b/src/Events/MarketplaceSubscription/MarketplaceSubscriptionSavedEvent.php
@@ -23,7 +23,7 @@ class MarketplaceSubscriptionSavedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceSubscription $model = null) {
+    public function __construct(?MarketplaceSubscription $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/MarketplaceSubscription/MarketplaceSubscriptionSavingEvent.php
+++ b/src/Events/MarketplaceSubscription/MarketplaceSubscriptionSavingEvent.php
@@ -23,7 +23,7 @@ class MarketplaceSubscriptionSavingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceSubscription $model = null) {
+    public function __construct(?MarketplaceSubscription $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/MarketplaceSubscription/MarketplaceSubscriptionUpdatedEvent.php
+++ b/src/Events/MarketplaceSubscription/MarketplaceSubscriptionUpdatedEvent.php
@@ -23,7 +23,7 @@ class MarketplaceSubscriptionUpdatedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceSubscription $model = null) {
+    public function __construct(?MarketplaceSubscription $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/MarketplaceSubscription/MarketplaceSubscriptionUpdatingEvent.php
+++ b/src/Events/MarketplaceSubscription/MarketplaceSubscriptionUpdatingEvent.php
@@ -23,7 +23,7 @@ class MarketplaceSubscriptionUpdatingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(MarketplaceSubscription $model = null) {
+    public function __construct(?MarketplaceSubscription $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Product/ProductCreatedEvent.php
+++ b/src/Events/Product/ProductCreatedEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductCreatedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Product $model = null) {
+    public function __construct(?Product $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Product/ProductCreatingEvent.php
+++ b/src/Events/Product/ProductCreatingEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductCreatingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Product $model = null) {
+    public function __construct(?Product $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Product/ProductDeletedEvent.php
+++ b/src/Events/Product/ProductDeletedEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductDeletedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Product $model = null) {
+    public function __construct(?Product $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Product/ProductDeletingEvent.php
+++ b/src/Events/Product/ProductDeletingEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductDeletingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Product $model = null) {
+    public function __construct(?Product $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Product/ProductRestoredEvent.php
+++ b/src/Events/Product/ProductRestoredEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductRestoredEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Product $model = null) {
+    public function __construct(?Product $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Product/ProductRestoringEvent.php
+++ b/src/Events/Product/ProductRestoringEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductRestoringEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Product $model = null) {
+    public function __construct(?Product $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Product/ProductRetrievedEvent.php
+++ b/src/Events/Product/ProductRetrievedEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductRetrievedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Product $model = null) {
+    public function __construct(?Product $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Product/ProductSavedEvent.php
+++ b/src/Events/Product/ProductSavedEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductSavedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Product $model = null) {
+    public function __construct(?Product $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Product/ProductSavingEvent.php
+++ b/src/Events/Product/ProductSavingEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductSavingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Product $model = null) {
+    public function __construct(?Product $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Product/ProductUpdatedEvent.php
+++ b/src/Events/Product/ProductUpdatedEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductUpdatedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Product $model = null) {
+    public function __construct(?Product $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Product/ProductUpdatingEvent.php
+++ b/src/Events/Product/ProductUpdatingEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductUpdatingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Product $model = null) {
+    public function __construct(?Product $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/ProductCatalog/ProductCatalogCreatedEvent.php
+++ b/src/Events/ProductCatalog/ProductCatalogCreatedEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductCatalogCreatedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalog $model = null) {
+    public function __construct(?ProductCatalog $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/ProductCatalog/ProductCatalogCreatingEvent.php
+++ b/src/Events/ProductCatalog/ProductCatalogCreatingEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductCatalogCreatingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalog $model = null) {
+    public function __construct(?ProductCatalog $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/ProductCatalog/ProductCatalogDeletedEvent.php
+++ b/src/Events/ProductCatalog/ProductCatalogDeletedEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductCatalogDeletedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalog $model = null) {
+    public function __construct(?ProductCatalog $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/ProductCatalog/ProductCatalogDeletingEvent.php
+++ b/src/Events/ProductCatalog/ProductCatalogDeletingEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductCatalogDeletingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalog $model = null) {
+    public function __construct(?ProductCatalog $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/ProductCatalog/ProductCatalogRestoredEvent.php
+++ b/src/Events/ProductCatalog/ProductCatalogRestoredEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductCatalogRestoredEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalog $model = null) {
+    public function __construct(?ProductCatalog $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/ProductCatalog/ProductCatalogRestoringEvent.php
+++ b/src/Events/ProductCatalog/ProductCatalogRestoringEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductCatalogRestoringEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalog $model = null) {
+    public function __construct(?ProductCatalog $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/ProductCatalog/ProductCatalogRetrievedEvent.php
+++ b/src/Events/ProductCatalog/ProductCatalogRetrievedEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductCatalogRetrievedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalog $model = null) {
+    public function __construct(?ProductCatalog $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/ProductCatalog/ProductCatalogSavedEvent.php
+++ b/src/Events/ProductCatalog/ProductCatalogSavedEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductCatalogSavedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalog $model = null) {
+    public function __construct(?ProductCatalog $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/ProductCatalog/ProductCatalogSavingEvent.php
+++ b/src/Events/ProductCatalog/ProductCatalogSavingEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductCatalogSavingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalog $model = null) {
+    public function __construct(?ProductCatalog $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/ProductCatalog/ProductCatalogUpdatedEvent.php
+++ b/src/Events/ProductCatalog/ProductCatalogUpdatedEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductCatalogUpdatedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalog $model = null) {
+    public function __construct(?ProductCatalog $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/ProductCatalog/ProductCatalogUpdatingEvent.php
+++ b/src/Events/ProductCatalog/ProductCatalogUpdatingEvent.php
@@ -23,7 +23,7 @@ class MarketplaceProductCatalogUpdatingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalog $model = null) {
+    public function __construct(?ProductCatalog $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/ProductCatalogs/ProductCatalogCreatedEvent.php
+++ b/src/Events/ProductCatalogs/ProductCatalogCreatedEvent.php
@@ -23,7 +23,7 @@ class ProductCatalogCreatedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalogs $model = null) {
+    public function __construct(?ProductCatalogs $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/ProductCatalogs/ProductCatalogCreatingEvent.php
+++ b/src/Events/ProductCatalogs/ProductCatalogCreatingEvent.php
@@ -23,7 +23,7 @@ class ProductCatalogCreatingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalogs $model = null) {
+    public function __construct(?ProductCatalogs $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/ProductCatalogs/ProductCatalogDeletedEvent.php
+++ b/src/Events/ProductCatalogs/ProductCatalogDeletedEvent.php
@@ -23,7 +23,7 @@ class ProductCatalogDeletedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalogs $model = null) {
+    public function __construct(?ProductCatalogs $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/ProductCatalogs/ProductCatalogDeletingEvent.php
+++ b/src/Events/ProductCatalogs/ProductCatalogDeletingEvent.php
@@ -23,7 +23,7 @@ class ProductCatalogDeletingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalogs $model = null) {
+    public function __construct(?ProductCatalogs $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/ProductCatalogs/ProductCatalogRestoredEvent.php
+++ b/src/Events/ProductCatalogs/ProductCatalogRestoredEvent.php
@@ -23,7 +23,7 @@ class ProductCatalogRestoredEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalogs $model = null) {
+    public function __construct(?ProductCatalogs $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/ProductCatalogs/ProductCatalogRestoringEvent.php
+++ b/src/Events/ProductCatalogs/ProductCatalogRestoringEvent.php
@@ -23,7 +23,7 @@ class ProductCatalogRestoringEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalogs $model = null) {
+    public function __construct(?ProductCatalogs $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/ProductCatalogs/ProductCatalogRetrievedEvent.php
+++ b/src/Events/ProductCatalogs/ProductCatalogRetrievedEvent.php
@@ -23,7 +23,7 @@ class ProductCatalogRetrievedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalogs $model = null) {
+    public function __construct(?ProductCatalogs $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/ProductCatalogs/ProductCatalogSavedEvent.php
+++ b/src/Events/ProductCatalogs/ProductCatalogSavedEvent.php
@@ -23,7 +23,7 @@ class ProductCatalogSavedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalogs $model = null) {
+    public function __construct(?ProductCatalogs $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/ProductCatalogs/ProductCatalogSavingEvent.php
+++ b/src/Events/ProductCatalogs/ProductCatalogSavingEvent.php
@@ -23,7 +23,7 @@ class ProductCatalogSavingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalogs $model = null) {
+    public function __construct(?ProductCatalogs $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/ProductCatalogs/ProductCatalogUpdatedEvent.php
+++ b/src/Events/ProductCatalogs/ProductCatalogUpdatedEvent.php
@@ -23,7 +23,7 @@ class ProductCatalogUpdatedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalogs $model = null) {
+    public function __construct(?ProductCatalogs $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/ProductCatalogs/ProductCatalogUpdatingEvent.php
+++ b/src/Events/ProductCatalogs/ProductCatalogUpdatingEvent.php
@@ -23,7 +23,7 @@ class ProductCatalogUpdatingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalogs $model = null) {
+    public function __construct(?ProductCatalogs $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/ProductCatalogs/ProductCatalogsCreatedEvent.php
+++ b/src/Events/ProductCatalogs/ProductCatalogsCreatedEvent.php
@@ -24,7 +24,7 @@ class ProductCatalogsCreatedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalogs $model = null)
+    public function __construct(?ProductCatalogs $model = null)
     {
         $this->_model = $model;
     }

--- a/src/Events/ProductCatalogs/ProductCatalogsCreatingEvent.php
+++ b/src/Events/ProductCatalogs/ProductCatalogsCreatingEvent.php
@@ -24,7 +24,7 @@ class ProductCatalogsCreatingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalogs $model = null)
+    public function __construct(?ProductCatalogs $model = null)
     {
         $this->_model = $model;
     }

--- a/src/Events/ProductCatalogs/ProductCatalogsDeletedEvent.php
+++ b/src/Events/ProductCatalogs/ProductCatalogsDeletedEvent.php
@@ -24,7 +24,7 @@ class ProductCatalogsDeletedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalogs $model = null)
+    public function __construct(?ProductCatalogs $model = null)
     {
         $this->_model = $model;
     }

--- a/src/Events/ProductCatalogs/ProductCatalogsDeletingEvent.php
+++ b/src/Events/ProductCatalogs/ProductCatalogsDeletingEvent.php
@@ -24,7 +24,7 @@ class ProductCatalogsDeletingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalogs $model = null)
+    public function __construct(?ProductCatalogs $model = null)
     {
         $this->_model = $model;
     }

--- a/src/Events/ProductCatalogs/ProductCatalogsRestoredEvent.php
+++ b/src/Events/ProductCatalogs/ProductCatalogsRestoredEvent.php
@@ -24,7 +24,7 @@ class ProductCatalogsRestoredEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalogs $model = null)
+    public function __construct(?ProductCatalogs $model = null)
     {
         $this->_model = $model;
     }

--- a/src/Events/ProductCatalogs/ProductCatalogsRestoringEvent.php
+++ b/src/Events/ProductCatalogs/ProductCatalogsRestoringEvent.php
@@ -24,7 +24,7 @@ class ProductCatalogsRestoringEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalogs $model = null)
+    public function __construct(?ProductCatalogs $model = null)
     {
         $this->_model = $model;
     }

--- a/src/Events/ProductCatalogs/ProductCatalogsRetrievedEvent.php
+++ b/src/Events/ProductCatalogs/ProductCatalogsRetrievedEvent.php
@@ -24,7 +24,7 @@ class ProductCatalogsRetrievedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalogs $model = null)
+    public function __construct(?ProductCatalogs $model = null)
     {
         $this->_model = $model;
     }

--- a/src/Events/ProductCatalogs/ProductCatalogsSavedEvent.php
+++ b/src/Events/ProductCatalogs/ProductCatalogsSavedEvent.php
@@ -24,7 +24,7 @@ class ProductCatalogsSavedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalogs $model = null)
+    public function __construct(?ProductCatalogs $model = null)
     {
         $this->_model = $model;
     }

--- a/src/Events/ProductCatalogs/ProductCatalogsSavingEvent.php
+++ b/src/Events/ProductCatalogs/ProductCatalogsSavingEvent.php
@@ -24,7 +24,7 @@ class ProductCatalogsSavingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalogs $model = null)
+    public function __construct(?ProductCatalogs $model = null)
     {
         $this->_model = $model;
     }

--- a/src/Events/ProductCatalogs/ProductCatalogsUpdatedEvent.php
+++ b/src/Events/ProductCatalogs/ProductCatalogsUpdatedEvent.php
@@ -24,7 +24,7 @@ class ProductCatalogsUpdatedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalogs $model = null)
+    public function __construct(?ProductCatalogs $model = null)
     {
         $this->_model = $model;
     }

--- a/src/Events/ProductCatalogs/ProductCatalogsUpdatingEvent.php
+++ b/src/Events/ProductCatalogs/ProductCatalogsUpdatingEvent.php
@@ -24,7 +24,7 @@ class ProductCatalogsUpdatingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(ProductCatalogs $model = null)
+    public function __construct(?ProductCatalogs $model = null)
     {
         $this->_model = $model;
     }

--- a/src/Events/Products/ProductCreatedEvent.php
+++ b/src/Events/Products/ProductCreatedEvent.php
@@ -23,7 +23,7 @@ class ProductCreatedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Products $model = null) {
+    public function __construct(?Products $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Products/ProductCreatingEvent.php
+++ b/src/Events/Products/ProductCreatingEvent.php
@@ -23,7 +23,7 @@ class ProductCreatingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Products $model = null) {
+    public function __construct(?Products $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Products/ProductDeletedEvent.php
+++ b/src/Events/Products/ProductDeletedEvent.php
@@ -23,7 +23,7 @@ class ProductDeletedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Products $model = null) {
+    public function __construct(?Products $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Products/ProductDeletingEvent.php
+++ b/src/Events/Products/ProductDeletingEvent.php
@@ -23,7 +23,7 @@ class ProductDeletingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Products $model = null) {
+    public function __construct(?Products $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Products/ProductRestoredEvent.php
+++ b/src/Events/Products/ProductRestoredEvent.php
@@ -23,7 +23,7 @@ class ProductRestoredEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Products $model = null) {
+    public function __construct(?Products $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Products/ProductRestoringEvent.php
+++ b/src/Events/Products/ProductRestoringEvent.php
@@ -23,7 +23,7 @@ class ProductRestoringEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Products $model = null) {
+    public function __construct(?Products $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Products/ProductRetrievedEvent.php
+++ b/src/Events/Products/ProductRetrievedEvent.php
@@ -23,7 +23,7 @@ class ProductRetrievedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Products $model = null) {
+    public function __construct(?Products $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Products/ProductSavedEvent.php
+++ b/src/Events/Products/ProductSavedEvent.php
@@ -23,7 +23,7 @@ class ProductSavedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Products $model = null) {
+    public function __construct(?Products $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Products/ProductSavingEvent.php
+++ b/src/Events/Products/ProductSavingEvent.php
@@ -23,7 +23,7 @@ class ProductSavingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Products $model = null) {
+    public function __construct(?Products $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Products/ProductUpdatedEvent.php
+++ b/src/Events/Products/ProductUpdatedEvent.php
@@ -23,7 +23,7 @@ class ProductUpdatedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Products $model = null) {
+    public function __construct(?Products $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Products/ProductUpdatingEvent.php
+++ b/src/Events/Products/ProductUpdatingEvent.php
@@ -23,7 +23,7 @@ class ProductUpdatingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Products $model = null) {
+    public function __construct(?Products $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Products/ProductsCreatedEvent.php
+++ b/src/Events/Products/ProductsCreatedEvent.php
@@ -23,7 +23,7 @@ class ProductsCreatedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Products $model = null) {
+    public function __construct(?Products $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Products/ProductsCreatingEvent.php
+++ b/src/Events/Products/ProductsCreatingEvent.php
@@ -23,7 +23,7 @@ class ProductsCreatingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Products $model = null) {
+    public function __construct(?Products $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Products/ProductsDeletedEvent.php
+++ b/src/Events/Products/ProductsDeletedEvent.php
@@ -23,7 +23,7 @@ class ProductsDeletedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Products $model = null) {
+    public function __construct(?Products $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Products/ProductsDeletingEvent.php
+++ b/src/Events/Products/ProductsDeletingEvent.php
@@ -23,7 +23,7 @@ class ProductsDeletingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Products $model = null) {
+    public function __construct(?Products $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Products/ProductsRestoredEvent.php
+++ b/src/Events/Products/ProductsRestoredEvent.php
@@ -23,7 +23,7 @@ class ProductsRestoredEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Products $model = null) {
+    public function __construct(?Products $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Products/ProductsRestoringEvent.php
+++ b/src/Events/Products/ProductsRestoringEvent.php
@@ -23,7 +23,7 @@ class ProductsRestoringEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Products $model = null) {
+    public function __construct(?Products $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Products/ProductsRetrievedEvent.php
+++ b/src/Events/Products/ProductsRetrievedEvent.php
@@ -23,7 +23,7 @@ class ProductsRetrievedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Products $model = null) {
+    public function __construct(?Products $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Products/ProductsSavedEvent.php
+++ b/src/Events/Products/ProductsSavedEvent.php
@@ -23,7 +23,7 @@ class ProductsSavedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Products $model = null) {
+    public function __construct(?Products $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Products/ProductsSavingEvent.php
+++ b/src/Events/Products/ProductsSavingEvent.php
@@ -23,7 +23,7 @@ class ProductsSavingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Products $model = null) {
+    public function __construct(?Products $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Products/ProductsUpdatedEvent.php
+++ b/src/Events/Products/ProductsUpdatedEvent.php
@@ -23,7 +23,7 @@ class ProductsUpdatedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Products $model = null) {
+    public function __construct(?Products $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Products/ProductsUpdatingEvent.php
+++ b/src/Events/Products/ProductsUpdatingEvent.php
@@ -23,7 +23,7 @@ class ProductsUpdatingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Products $model = null) {
+    public function __construct(?Products $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscription/SubscriptionCreatedEvent.php
+++ b/src/Events/Subscription/SubscriptionCreatedEvent.php
@@ -23,7 +23,7 @@ class MarketplaceSubscriptionCreatedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscription $model = null) {
+    public function __construct(?Subscription $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscription/SubscriptionCreatingEvent.php
+++ b/src/Events/Subscription/SubscriptionCreatingEvent.php
@@ -23,7 +23,7 @@ class MarketplaceSubscriptionCreatingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscription $model = null) {
+    public function __construct(?Subscription $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscription/SubscriptionDeletedEvent.php
+++ b/src/Events/Subscription/SubscriptionDeletedEvent.php
@@ -23,7 +23,7 @@ class MarketplaceSubscriptionDeletedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscription $model = null) {
+    public function __construct(?Subscription $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscription/SubscriptionDeletingEvent.php
+++ b/src/Events/Subscription/SubscriptionDeletingEvent.php
@@ -23,7 +23,7 @@ class MarketplaceSubscriptionDeletingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscription $model = null) {
+    public function __construct(?Subscription $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscription/SubscriptionRestoredEvent.php
+++ b/src/Events/Subscription/SubscriptionRestoredEvent.php
@@ -23,7 +23,7 @@ class MarketplaceSubscriptionRestoredEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscription $model = null) {
+    public function __construct(?Subscription $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscription/SubscriptionRestoringEvent.php
+++ b/src/Events/Subscription/SubscriptionRestoringEvent.php
@@ -23,7 +23,7 @@ class MarketplaceSubscriptionRestoringEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscription $model = null) {
+    public function __construct(?Subscription $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscription/SubscriptionRetrievedEvent.php
+++ b/src/Events/Subscription/SubscriptionRetrievedEvent.php
@@ -23,7 +23,7 @@ class MarketplaceSubscriptionRetrievedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscription $model = null) {
+    public function __construct(?Subscription $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscription/SubscriptionSavedEvent.php
+++ b/src/Events/Subscription/SubscriptionSavedEvent.php
@@ -23,7 +23,7 @@ class MarketplaceSubscriptionSavedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscription $model = null) {
+    public function __construct(?Subscription $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscription/SubscriptionSavingEvent.php
+++ b/src/Events/Subscription/SubscriptionSavingEvent.php
@@ -23,7 +23,7 @@ class MarketplaceSubscriptionSavingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscription $model = null) {
+    public function __construct(?Subscription $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscription/SubscriptionUpdatedEvent.php
+++ b/src/Events/Subscription/SubscriptionUpdatedEvent.php
@@ -23,7 +23,7 @@ class MarketplaceSubscriptionUpdatedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscription $model = null) {
+    public function __construct(?Subscription $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscription/SubscriptionUpdatingEvent.php
+++ b/src/Events/Subscription/SubscriptionUpdatingEvent.php
@@ -23,7 +23,7 @@ class MarketplaceSubscriptionUpdatingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscription $model = null) {
+    public function __construct(?Subscription $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscriptions/SubscriptionCreatedEvent.php
+++ b/src/Events/Subscriptions/SubscriptionCreatedEvent.php
@@ -23,7 +23,7 @@ class SubscriptionCreatedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscriptions $model = null) {
+    public function __construct(?Subscriptions $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscriptions/SubscriptionCreatingEvent.php
+++ b/src/Events/Subscriptions/SubscriptionCreatingEvent.php
@@ -23,7 +23,7 @@ class SubscriptionCreatingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscriptions $model = null) {
+    public function __construct(?Subscriptions $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscriptions/SubscriptionDeletedEvent.php
+++ b/src/Events/Subscriptions/SubscriptionDeletedEvent.php
@@ -23,7 +23,7 @@ class SubscriptionDeletedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscriptions $model = null) {
+    public function __construct(?Subscriptions $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscriptions/SubscriptionDeletingEvent.php
+++ b/src/Events/Subscriptions/SubscriptionDeletingEvent.php
@@ -23,7 +23,7 @@ class SubscriptionDeletingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscriptions $model = null) {
+    public function __construct(?Subscriptions $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscriptions/SubscriptionRestoredEvent.php
+++ b/src/Events/Subscriptions/SubscriptionRestoredEvent.php
@@ -23,7 +23,7 @@ class SubscriptionRestoredEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscriptions $model = null) {
+    public function __construct(?Subscriptions $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscriptions/SubscriptionRestoringEvent.php
+++ b/src/Events/Subscriptions/SubscriptionRestoringEvent.php
@@ -23,7 +23,7 @@ class SubscriptionRestoringEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscriptions $model = null) {
+    public function __construct(?Subscriptions $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscriptions/SubscriptionRetrievedEvent.php
+++ b/src/Events/Subscriptions/SubscriptionRetrievedEvent.php
@@ -23,7 +23,7 @@ class SubscriptionRetrievedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscriptions $model = null) {
+    public function __construct(?Subscriptions $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscriptions/SubscriptionSavedEvent.php
+++ b/src/Events/Subscriptions/SubscriptionSavedEvent.php
@@ -23,7 +23,7 @@ class SubscriptionSavedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscriptions $model = null) {
+    public function __construct(?Subscriptions $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscriptions/SubscriptionSavingEvent.php
+++ b/src/Events/Subscriptions/SubscriptionSavingEvent.php
@@ -23,7 +23,7 @@ class SubscriptionSavingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscriptions $model = null) {
+    public function __construct(?Subscriptions $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscriptions/SubscriptionUpdatedEvent.php
+++ b/src/Events/Subscriptions/SubscriptionUpdatedEvent.php
@@ -23,7 +23,7 @@ class SubscriptionUpdatedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscriptions $model = null) {
+    public function __construct(?Subscriptions $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscriptions/SubscriptionUpdatingEvent.php
+++ b/src/Events/Subscriptions/SubscriptionUpdatingEvent.php
@@ -23,7 +23,7 @@ class SubscriptionUpdatingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscriptions $model = null) {
+    public function __construct(?Subscriptions $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscriptions/SubscriptionsCreatedEvent.php
+++ b/src/Events/Subscriptions/SubscriptionsCreatedEvent.php
@@ -23,7 +23,7 @@ class SubscriptionsCreatedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscriptions $model = null) {
+    public function __construct(?Subscriptions $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscriptions/SubscriptionsCreatingEvent.php
+++ b/src/Events/Subscriptions/SubscriptionsCreatingEvent.php
@@ -23,7 +23,7 @@ class SubscriptionsCreatingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscriptions $model = null) {
+    public function __construct(?Subscriptions $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscriptions/SubscriptionsDeletedEvent.php
+++ b/src/Events/Subscriptions/SubscriptionsDeletedEvent.php
@@ -23,7 +23,7 @@ class SubscriptionsDeletedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscriptions $model = null) {
+    public function __construct(?Subscriptions $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscriptions/SubscriptionsDeletingEvent.php
+++ b/src/Events/Subscriptions/SubscriptionsDeletingEvent.php
@@ -23,7 +23,7 @@ class SubscriptionsDeletingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscriptions $model = null) {
+    public function __construct(?Subscriptions $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscriptions/SubscriptionsRestoredEvent.php
+++ b/src/Events/Subscriptions/SubscriptionsRestoredEvent.php
@@ -23,7 +23,7 @@ class SubscriptionsRestoredEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscriptions $model = null) {
+    public function __construct(?Subscriptions $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscriptions/SubscriptionsRestoringEvent.php
+++ b/src/Events/Subscriptions/SubscriptionsRestoringEvent.php
@@ -23,7 +23,7 @@ class SubscriptionsRestoringEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscriptions $model = null) {
+    public function __construct(?Subscriptions $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscriptions/SubscriptionsRetrievedEvent.php
+++ b/src/Events/Subscriptions/SubscriptionsRetrievedEvent.php
@@ -23,7 +23,7 @@ class SubscriptionsRetrievedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscriptions $model = null) {
+    public function __construct(?Subscriptions $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscriptions/SubscriptionsSavedEvent.php
+++ b/src/Events/Subscriptions/SubscriptionsSavedEvent.php
@@ -23,7 +23,7 @@ class SubscriptionsSavedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscriptions $model = null) {
+    public function __construct(?Subscriptions $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscriptions/SubscriptionsSavingEvent.php
+++ b/src/Events/Subscriptions/SubscriptionsSavingEvent.php
@@ -23,7 +23,7 @@ class SubscriptionsSavingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscriptions $model = null) {
+    public function __construct(?Subscriptions $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscriptions/SubscriptionsUpdatedEvent.php
+++ b/src/Events/Subscriptions/SubscriptionsUpdatedEvent.php
@@ -23,7 +23,7 @@ class SubscriptionsUpdatedEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscriptions $model = null) {
+    public function __construct(?Subscriptions $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Events/Subscriptions/SubscriptionsUpdatingEvent.php
+++ b/src/Events/Subscriptions/SubscriptionsUpdatingEvent.php
@@ -23,7 +23,7 @@ class SubscriptionsUpdatingEvent
      */
     protected $timestamp = null;
 
-    public function __construct(Subscriptions $model = null) {
+    public function __construct(?Subscriptions $model = null) {
         $this->_model = $model;
     }
 

--- a/src/Http/Transformers/AbstractTransformers/AbstractAccountsTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractAccountsTransformer.php
@@ -55,7 +55,7 @@ class AbstractAccountsTransformer extends AbstractTransformer
     public function transform(Accounts $model)
     {
                                                 $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
-                        
+
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,

--- a/src/Http/Transformers/AbstractTransformers/AbstractMarketsPerspectiveTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractMarketsPerspectiveTransformer.php
@@ -60,7 +60,7 @@ class AbstractMarketsPerspectiveTransformer extends AbstractTransformer
                                                             $commonCountryId = \NextDeveloper\Commons\Database\Models\Countries::where('id', $model->common_country_id)->first();
                                                             $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
                                                             $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
-                        
+
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,

--- a/src/Http/Transformers/AbstractTransformers/AbstractMarketsTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractMarketsTransformer.php
@@ -60,7 +60,7 @@ class AbstractMarketsTransformer extends AbstractTransformer
                                                             $commonCountryId = \NextDeveloper\Commons\Database\Models\Countries::where('id', $model->common_country_id)->first();
                                                             $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
                                                             $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
-                        
+
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,

--- a/src/Http/Transformers/AbstractTransformers/AbstractOrderItemsPerspectiveTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractOrderItemsPerspectiveTransformer.php
@@ -58,7 +58,7 @@ class AbstractOrderItemsPerspectiveTransformer extends AbstractTransformer
                                                             $marketplaceProductCatalogId = \NextDeveloper\Marketplace\Database\Models\ProductCatalogs::where('id', $model->marketplace_product_catalog_id)->first();
                                                             $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
                                                             $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
-                        
+
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,

--- a/src/Http/Transformers/AbstractTransformers/AbstractOrderItemsTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractOrderItemsTransformer.php
@@ -58,7 +58,7 @@ class AbstractOrderItemsTransformer extends AbstractTransformer
                                                             $marketplaceProductCatalogId = \NextDeveloper\Marketplace\Database\Models\ProductCatalogs::where('id', $model->marketplace_product_catalog_id)->first();
                                                             $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
                                                             $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
-                        
+
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,

--- a/src/Http/Transformers/AbstractTransformers/AbstractOrderStatusHistoriesTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractOrderStatusHistoriesTransformer.php
@@ -57,7 +57,7 @@ class AbstractOrderStatusHistoriesTransformer extends AbstractTransformer
                                                 $marketplaceOrderId = \NextDeveloper\Marketplace\Database\Models\Orders::where('id', $model->marketplace_order_id)->first();
                                                             $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
                                                             $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
-                        
+
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,

--- a/src/Http/Transformers/AbstractTransformers/AbstractOrdersTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractOrdersTransformer.php
@@ -59,7 +59,7 @@ class AbstractOrdersTransformer extends AbstractTransformer
                                                             $marketplaceProductId = \NextDeveloper\Marketplace\Database\Models\Products::where('id', $model->marketplace_product_id)->first();
                                                             $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
                                                             $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
-                        
+
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,

--- a/src/Http/Transformers/AbstractTransformers/AbstractProductCatalogMappingsTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractProductCatalogMappingsTransformer.php
@@ -56,7 +56,7 @@ class AbstractProductCatalogMappingsTransformer extends AbstractTransformer
     {
                                                 $marketplaceProductCatalogId = \NextDeveloper\Marketplace\Database\Models\ProductCatalogs::where('id', $model->marketplace_product_catalog_id)->first();
                                                             $marketplaceProviderId = \NextDeveloper\Marketplace\Database\Models\Providers::where('id', $model->marketplace_provider_id)->first();
-                        
+
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,

--- a/src/Http/Transformers/AbstractTransformers/AbstractProductCatalogsPerspectiveTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractProductCatalogsPerspectiveTransformer.php
@@ -57,7 +57,7 @@ class AbstractProductCatalogsPerspectiveTransformer extends AbstractTransformer
                                                 $marketplaceProductId = \NextDeveloper\Marketplace\Database\Models\Products::where('id', $model->marketplace_product_id)->first();
                                                             $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
                                                             $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
-                        
+
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,

--- a/src/Http/Transformers/AbstractTransformers/AbstractProductCatalogsTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractProductCatalogsTransformer.php
@@ -58,7 +58,7 @@ class AbstractProductCatalogsTransformer extends AbstractTransformer
                                                             $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
                                                             $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
                                                             $commonCurrencyId = \NextDeveloper\Commons\Database\Models\Currencies::where('id', $model->common_currency_id)->first();
-                        
+
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,

--- a/src/Http/Transformers/AbstractTransformers/AbstractProductMappingsTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractProductMappingsTransformer.php
@@ -56,7 +56,7 @@ class AbstractProductMappingsTransformer extends AbstractTransformer
     {
                                                 $marketplaceProductId = \NextDeveloper\Marketplace\Database\Models\Products::where('id', $model->marketplace_product_id)->first();
                                                             $marketplaceProviderId = \NextDeveloper\Marketplace\Database\Models\Providers::where('id', $model->marketplace_provider_id)->first();
-                        
+
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,

--- a/src/Http/Transformers/AbstractTransformers/AbstractProductsPerspectiveTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractProductsPerspectiveTransformer.php
@@ -58,7 +58,7 @@ class AbstractProductsPerspectiveTransformer extends AbstractTransformer
                                                             $marketplaceMarketId = \NextDeveloper\Marketplace\Database\Models\Markets::where('id', $model->marketplace_market_id)->first();
                                                             $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
                                                             $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
-                        
+
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,

--- a/src/Http/Transformers/AbstractTransformers/AbstractProductsTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractProductsTransformer.php
@@ -60,7 +60,7 @@ class AbstractProductsTransformer extends AbstractTransformer
                                                             $marketplaceMarketId = \NextDeveloper\Marketplace\Database\Models\Markets::where('id', $model->marketplace_market_id)->first();
                                                             $marketplaceProviderId = \NextDeveloper\Marketplace\Database\Models\Providers::where('id', $model->marketplace_provider_id)->first();
                                                             $parentMarketplaceProductId = \NextDeveloper\Marketplace\Database\Models\Products::where('id', $model->parent_marketplace_product_id)->first();
-                        
+
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,

--- a/src/Http/Transformers/AbstractTransformers/AbstractProvidersTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractProvidersTransformer.php
@@ -57,7 +57,7 @@ class AbstractProvidersTransformer extends AbstractTransformer
                                                 $marketplaceMarketId = \NextDeveloper\Marketplace\Database\Models\Markets::where('id', $model->marketplace_market_id)->first();
                                                             $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
                                                             $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
-                        
+
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,

--- a/src/Http/Transformers/AbstractTransformers/AbstractStatusMappingsTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractStatusMappingsTransformer.php
@@ -55,7 +55,7 @@ class AbstractStatusMappingsTransformer extends AbstractTransformer
     public function transform(StatusMappings $model)
     {
                                                 $marketplaceProviderId = \NextDeveloper\Marketplace\Database\Models\Providers::where('id', $model->marketplace_provider_id)->first();
-                        
+
         return $this->buildPayload(
             [
             'id'  =>  $model->id,

--- a/src/Http/Transformers/AbstractTransformers/AbstractSubscriptionsTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractSubscriptionsTransformer.php
@@ -57,7 +57,7 @@ class AbstractSubscriptionsTransformer extends AbstractTransformer
                                                 $marketplaceProductCatalogId = \NextDeveloper\Marketplace\Database\Models\ProductCatalogs::where('id', $model->marketplace_product_catalog_id)->first();
                                                             $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
                                                             $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
-                        
+
         return $this->buildPayload(
             [
             'id'  =>  $model->uuid,

--- a/src/Services/AbstractServices/AbstractAccountsService.php
+++ b/src/Services/AbstractServices/AbstractAccountsService.php
@@ -25,7 +25,7 @@ use NextDeveloper\Commons\Exceptions\NotAllowedException;
  */
 class AbstractAccountsService
 {
-    public static function get(AccountsQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
+    public static function get(?AccountsQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
     {
         $enablePaginate = array_key_exists('paginate', $params);
 

--- a/src/Services/AbstractServices/AbstractMarketsPerspectiveService.php
+++ b/src/Services/AbstractServices/AbstractMarketsPerspectiveService.php
@@ -25,7 +25,7 @@ use NextDeveloper\Commons\Exceptions\NotAllowedException;
  */
 class AbstractMarketsPerspectiveService
 {
-    public static function get(MarketsPerspectiveQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
+    public static function get(?MarketsPerspectiveQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
     {
         $enablePaginate = array_key_exists('paginate', $params);
 

--- a/src/Services/AbstractServices/AbstractMarketsService.php
+++ b/src/Services/AbstractServices/AbstractMarketsService.php
@@ -25,7 +25,7 @@ use NextDeveloper\Commons\Exceptions\NotAllowedException;
  */
 class AbstractMarketsService
 {
-    public static function get(MarketsQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
+    public static function get(?MarketsQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
     {
         $enablePaginate = array_key_exists('paginate', $params);
 

--- a/src/Services/AbstractServices/AbstractOrderItemsPerspectiveService.php
+++ b/src/Services/AbstractServices/AbstractOrderItemsPerspectiveService.php
@@ -25,7 +25,7 @@ use NextDeveloper\Commons\Exceptions\NotAllowedException;
  */
 class AbstractOrderItemsPerspectiveService
 {
-    public static function get(OrderItemsPerspectiveQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
+    public static function get(?OrderItemsPerspectiveQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
     {
         $enablePaginate = array_key_exists('paginate', $params);
 
@@ -196,7 +196,7 @@ class AbstractOrderItemsPerspectiveService
                 $data['marketplace_product_catalog_id']
             );
         }
-                        
+
         try {
             $model = OrderItemsPerspective::create($data);
         } catch(\Exception $e) {
@@ -254,7 +254,7 @@ class AbstractOrderItemsPerspectiveService
                 $data['marketplace_product_catalog_id']
             );
         }
-    
+
         try {
             $isUpdated = $model->update($data);
             $model = $model->fresh();

--- a/src/Services/AbstractServices/AbstractOrderItemsService.php
+++ b/src/Services/AbstractServices/AbstractOrderItemsService.php
@@ -25,7 +25,7 @@ use NextDeveloper\Commons\Exceptions\NotAllowedException;
  */
 class AbstractOrderItemsService
 {
-    public static function get(OrderItemsQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
+    public static function get(?OrderItemsQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
     {
         $enablePaginate = array_key_exists('paginate', $params);
 

--- a/src/Services/AbstractServices/AbstractOrderStatusHistoriesService.php
+++ b/src/Services/AbstractServices/AbstractOrderStatusHistoriesService.php
@@ -25,7 +25,7 @@ use NextDeveloper\Commons\Exceptions\NotAllowedException;
  */
 class AbstractOrderStatusHistoriesService
 {
-    public static function get(OrderStatusHistoriesQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
+    public static function get(?OrderStatusHistoriesQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
     {
         $enablePaginate = array_key_exists('paginate', $params);
 
@@ -134,7 +134,7 @@ class AbstractOrderStatusHistoriesService
         return OrderStatusHistories::where('id', $id)->first();
     }
 
-    
+
     /**
      * This method returns the sub objects of the related models
      *
@@ -183,7 +183,7 @@ class AbstractOrderStatusHistoriesService
                 $data['iam_account_id']
             );
         }
-            
+
         if(!array_key_exists('iam_account_id', $data)) {
             $data['iam_account_id'] = UserHelper::currentAccount()->id;
         }
@@ -193,11 +193,11 @@ class AbstractOrderStatusHistoriesService
                 $data['iam_user_id']
             );
         }
-                    
+
         if(!array_key_exists('iam_user_id', $data)) {
             $data['iam_user_id']    = UserHelper::me()->id;
         }
-            
+
         try {
             $model = OrderStatusHistories::create($data);
         } catch(\Exception $e) {
@@ -263,7 +263,7 @@ class AbstractOrderStatusHistoriesService
                 $data['iam_user_id']
             );
         }
-    
+
         Events::fire('updating:NextDeveloper\Marketplace\OrderStatusHistories', $model);
 
         try {

--- a/src/Services/AbstractServices/AbstractOrdersService.php
+++ b/src/Services/AbstractServices/AbstractOrdersService.php
@@ -25,7 +25,7 @@ use NextDeveloper\Commons\Exceptions\NotAllowedException;
  */
 class AbstractOrdersService
 {
-    public static function get(OrdersQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
+    public static function get(?OrdersQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
     {
         $enablePaginate = array_key_exists('paginate', $params);
 
@@ -134,7 +134,7 @@ class AbstractOrdersService
         return Orders::where('id', $id)->first();
     }
 
-    
+
     /**
      * This method returns the sub objects of the related models
      *
@@ -195,7 +195,7 @@ class AbstractOrdersService
                 $data['iam_account_id']
             );
         }
-            
+
         if(!array_key_exists('iam_account_id', $data)) {
             $data['iam_account_id'] = UserHelper::currentAccount()->id;
         }
@@ -205,11 +205,11 @@ class AbstractOrdersService
                 $data['iam_user_id']
             );
         }
-                    
+
         if(!array_key_exists('iam_user_id', $data)) {
             $data['iam_user_id']    = UserHelper::me()->id;
         }
-            
+
         try {
             $model = Orders::create($data);
         } catch(\Exception $e) {
@@ -287,7 +287,7 @@ class AbstractOrdersService
                 $data['iam_user_id']
             );
         }
-    
+
         Events::fire('updating:NextDeveloper\Marketplace\Orders', $model);
 
         try {

--- a/src/Services/AbstractServices/AbstractProductCatalogMappingsService.php
+++ b/src/Services/AbstractServices/AbstractProductCatalogMappingsService.php
@@ -25,7 +25,7 @@ use NextDeveloper\Commons\Exceptions\NotAllowedException;
  */
 class AbstractProductCatalogMappingsService
 {
-    public static function get(ProductCatalogMappingsQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
+    public static function get(?ProductCatalogMappingsQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
     {
         $enablePaginate = array_key_exists('paginate', $params);
 
@@ -134,7 +134,7 @@ class AbstractProductCatalogMappingsService
         return ProductCatalogMappings::where('id', $id)->first();
     }
 
-    
+
     /**
      * This method returns the sub objects of the related models
      *
@@ -183,7 +183,7 @@ class AbstractProductCatalogMappingsService
                 $data['marketplace_provider_id']
             );
         }
-                        
+
         try {
             $model = ProductCatalogMappings::create($data);
         } catch(\Exception $e) {
@@ -243,7 +243,7 @@ class AbstractProductCatalogMappingsService
                 $data['marketplace_provider_id']
             );
         }
-    
+
         Events::fire('updating:NextDeveloper\Marketplace\ProductCatalogMappings', $model);
 
         try {

--- a/src/Services/AbstractServices/AbstractProductCatalogsPerspectiveService.php
+++ b/src/Services/AbstractServices/AbstractProductCatalogsPerspectiveService.php
@@ -25,7 +25,7 @@ use NextDeveloper\Commons\Exceptions\NotAllowedException;
  */
 class AbstractProductCatalogsPerspectiveService
 {
-    public static function get(ProductCatalogsPerspectiveQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
+    public static function get(?ProductCatalogsPerspectiveQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
     {
         $enablePaginate = array_key_exists('paginate', $params);
 

--- a/src/Services/AbstractServices/AbstractProductCatalogsService.php
+++ b/src/Services/AbstractServices/AbstractProductCatalogsService.php
@@ -25,7 +25,7 @@ use NextDeveloper\Commons\Exceptions\NotAllowedException;
  */
 class AbstractProductCatalogsService
 {
-    public static function get(ProductCatalogsQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
+    public static function get(?ProductCatalogsQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
     {
         $enablePaginate = array_key_exists('paginate', $params);
 

--- a/src/Services/AbstractServices/AbstractProductMappingsService.php
+++ b/src/Services/AbstractServices/AbstractProductMappingsService.php
@@ -25,7 +25,7 @@ use NextDeveloper\Commons\Exceptions\NotAllowedException;
  */
 class AbstractProductMappingsService
 {
-    public static function get(ProductMappingsQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
+    public static function get(?ProductMappingsQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
     {
         $enablePaginate = array_key_exists('paginate', $params);
 
@@ -134,7 +134,7 @@ class AbstractProductMappingsService
         return ProductMappings::where('id', $id)->first();
     }
 
-    
+
     /**
      * This method returns the sub objects of the related models
      *
@@ -183,7 +183,7 @@ class AbstractProductMappingsService
                 $data['marketplace_provider_id']
             );
         }
-                        
+
         try {
             $model = ProductMappings::create($data);
         } catch(\Exception $e) {
@@ -243,7 +243,7 @@ class AbstractProductMappingsService
                 $data['marketplace_provider_id']
             );
         }
-    
+
         Events::fire('updating:NextDeveloper\Marketplace\ProductMappings', $model);
 
         try {

--- a/src/Services/AbstractServices/AbstractProductsPerspectiveService.php
+++ b/src/Services/AbstractServices/AbstractProductsPerspectiveService.php
@@ -25,7 +25,7 @@ use NextDeveloper\Commons\Exceptions\NotAllowedException;
  */
 class AbstractProductsPerspectiveService
 {
-    public static function get(ProductsPerspectiveQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
+    public static function get(?ProductsPerspectiveQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
     {
         $enablePaginate = array_key_exists('paginate', $params);
 

--- a/src/Services/AbstractServices/AbstractProductsService.php
+++ b/src/Services/AbstractServices/AbstractProductsService.php
@@ -25,7 +25,7 @@ use NextDeveloper\Commons\Exceptions\NotAllowedException;
  */
 class AbstractProductsService
 {
-    public static function get(ProductsQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
+    public static function get(?ProductsQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
     {
         $enablePaginate = array_key_exists('paginate', $params);
 

--- a/src/Services/AbstractServices/AbstractProvidersService.php
+++ b/src/Services/AbstractServices/AbstractProvidersService.php
@@ -25,7 +25,7 @@ use NextDeveloper\Commons\Exceptions\NotAllowedException;
  */
 class AbstractProvidersService
 {
-    public static function get(ProvidersQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
+    public static function get(?ProvidersQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
     {
         $enablePaginate = array_key_exists('paginate', $params);
 
@@ -182,7 +182,7 @@ class AbstractProvidersService
                 $data['iam_account_id']
             );
         }
-            
+
         if(!array_key_exists('iam_account_id', $data)) {
             $data['iam_account_id'] = UserHelper::currentAccount()->id;
         }
@@ -192,11 +192,11 @@ class AbstractProvidersService
                 $data['iam_user_id']
             );
         }
-                    
+
         if(!array_key_exists('iam_user_id', $data)) {
             $data['iam_user_id']    = UserHelper::me()->id;
         }
-            
+
         try {
             $model = Providers::create($data);
         } catch(\Exception $e) {
@@ -262,7 +262,7 @@ class AbstractProvidersService
                 $data['iam_user_id']
             );
         }
-    
+
         Events::fire('updating:NextDeveloper\Marketplace\Providers', $model);
 
         try {

--- a/src/Services/AbstractServices/AbstractStatusMappingsService.php
+++ b/src/Services/AbstractServices/AbstractStatusMappingsService.php
@@ -25,7 +25,7 @@ use NextDeveloper\Commons\Exceptions\NotAllowedException;
  */
 class AbstractStatusMappingsService
 {
-    public static function get(StatusMappingsQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
+    public static function get(?StatusMappingsQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
     {
         $enablePaginate = array_key_exists('paginate', $params);
 
@@ -134,7 +134,7 @@ class AbstractStatusMappingsService
         return StatusMappings::where('id', $id)->first();
     }
 
-    
+
     /**
      * This method returns the sub objects of the related models
      *
@@ -177,7 +177,7 @@ class AbstractStatusMappingsService
                 $data['marketplace_provider_id']
             );
         }
-                        
+
         try {
             $model = StatusMappings::create($data);
         } catch(\Exception $e) {
@@ -231,7 +231,7 @@ class AbstractStatusMappingsService
                 $data['marketplace_provider_id']
             );
         }
-    
+
         Events::fire('updating:NextDeveloper\Marketplace\StatusMappings', $model);
 
         try {

--- a/src/Services/AbstractServices/AbstractSubscriptionsService.php
+++ b/src/Services/AbstractServices/AbstractSubscriptionsService.php
@@ -25,7 +25,7 @@ use NextDeveloper\Commons\Exceptions\NotAllowedException;
  */
 class AbstractSubscriptionsService
 {
-    public static function get(SubscriptionsQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
+    public static function get(?SubscriptionsQueryFilter $filter = null, array $params = []) : Collection|LengthAwarePaginator
     {
         $enablePaginate = array_key_exists('paginate', $params);
 

--- a/src/Services/ProductsService.php
+++ b/src/Services/ProductsService.php
@@ -16,7 +16,7 @@ class ProductsService extends AbstractProductsService
 {
 
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
-    public static function get(ProductsQueryFilter $filter = null, array $params = []): \Illuminate\Database\Eloquent\Collection|\Illuminate\Contracts\Pagination\LengthAwarePaginator
+    public static function get(?ProductsQueryFilter $filter = null, array $params = []): \Illuminate\Database\Eloquent\Collection|\Illuminate\Contracts\Pagination\LengthAwarePaginator
     {
         return parent::get($filter, $params);
     }


### PR DESCRIPTION
Applies Rector's ExplicitNullableParamTypeRector across the package: `Type $x = null` -> `?Type $x = null`. Fixes the PHP 8.4 implicit-nullable-parameter deprecation notice.