### PR TITLE
docs: add DDL schema files for module tables and views

### DIFF
--- a/schemas/marketplace_accounts.sql
+++ b/schemas/marketplace_accounts.sql
@@ -1,0 +1,12 @@
+-- PostgreSQL
+
+CREATE TABLE marketplace_accounts (
+    id                  integer NOT NULL DEFAULT nextval('marketplace_accounts_id_seq'::regclass),
+    uuid                uuid DEFAULT gen_random_uuid(),
+    iam_account_id      bigint NOT NULL,
+    is_service_enabled  boolean NOT NULL DEFAULT false,
+    created_at          timestamp with time zone DEFAULT now(),
+    updated_at          timestamp with time zone DEFAULT now(),
+    deleted_at          timestamp with time zone,
+    CONSTRAINT marketplace_accounts_pkey PRIMARY KEY (id)
+);

--- a/schemas/marketplace_markets.sql
+++ b/schemas/marketplace_markets.sql
@@ -1,0 +1,20 @@
+-- PostgreSQL
+
+CREATE TABLE marketplace_markets (
+    id                  bigint NOT NULL DEFAULT nextval('marketplace_markets_id_seq'::regclass),
+    uuid                uuid DEFAULT gen_random_uuid(),
+    name                text NOT NULL, -- [label:"This will be the name of the marketplace. If you make this market public, the market will be listed with this name."]
+    description         text, -- [ui:markdown][label:"Please give us a brief information about your marketplace"]
+    common_domain_id    bigint NOT NULL,
+    is_public           boolean NOT NULL DEFAULT false, -- [label:"If you make your market public, then everybody will see your products."]
+    is_active           boolean NOT NULL DEFAULT true,
+    common_currency_id  bigint NOT NULL,
+    common_language_id  bigint NOT NULL,
+    common_country_id   bigint NOT NULL,
+    iam_account_id      bigint NOT NULL,
+    iam_user_id         bigint NOT NULL,
+    created_at          timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at          timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at          timestamp with time zone,
+    CONSTRAINT marketplace_markets_pkey PRIMARY KEY (id)
+);

--- a/schemas/marketplace_markets_perspective.sql
+++ b/schemas/marketplace_markets_perspective.sql
@@ -1,0 +1,41 @@
+-- PostgreSQL
+-- VIEW (read-only; re-run this file with CREATE OR REPLACE VIEW whenever the SELECT needs to change)
+
+CREATE OR REPLACE VIEW marketplace_markets_perspective AS
+SELECT id,
+    uuid,
+    name,
+    description,
+    ( SELECT n_cd.name
+           FROM common_domains n_cd
+          WHERE n_cd.id = mm.common_domain_id) AS domain,
+    common_domain_id,
+    ( SELECT n_cc.name
+           FROM common_currencies n_cc
+          WHERE n_cc.id = mm.common_currency_id) AS currency,
+    common_currency_id,
+    ( SELECT n_cl.name
+           FROM common_languages n_cl
+          WHERE n_cl.id = mm.common_language_id) AS language,
+    common_language_id,
+    ( SELECT n_c.name
+           FROM common_countries n_c
+          WHERE n_c.id = mm.common_country_id) AS country,
+    common_country_id,
+    ( SELECT count(n_mp.id) AS count
+           FROM marketplace_products n_mp
+          WHERE n_mp.marketplace_market_id = mm.id AND n_mp.is_active = true AND n_mp.is_public = true) AS product_count,
+    is_public,
+    is_active,
+    ( SELECT c_ia.name
+           FROM iam_accounts c_ia
+          WHERE c_ia.id = mm.iam_account_id) AS maintainer,
+    ( SELECT n_ia.fullname
+           FROM iam_users n_ia
+          WHERE n_ia.id = mm.iam_user_id) AS responsible,
+    iam_account_id,
+    iam_user_id,
+    created_at,
+    updated_at,
+    deleted_at
+   FROM marketplace_markets mm;

--- a/schemas/marketplace_order_items.sql
+++ b/schemas/marketplace_order_items.sql
@@ -1,0 +1,21 @@
+-- PostgreSQL
+-- Table to manage individual items within a marketplace order
+
+CREATE TABLE marketplace_order_items (
+    id                              bigint NOT NULL DEFAULT nextval('marketplace_order_items_id_seq'::regclass),
+    uuid                            uuid NOT NULL DEFAULT gen_random_uuid(),
+    marketplace_order_id            bigint NOT NULL, -- The order this item belongs to
+    marketplace_product_catalog_id  bigint NOT NULL, -- The product being ordered from the marketplace catalog
+    quantity                        integer NOT NULL DEFAULT 1, -- Quantity of the product ordered
+    price_per_item                  numeric(10,2) NOT NULL, -- Price per item at the time of order
+    total_price                     numeric(10,2) NOT NULL, -- Total price for this item (quantity * price_per_item)
+    modifiers                       json, -- Any modifiers or customizations for the product
+    special_instructions            text, -- Special instructions from the customer
+    item_data                       json, -- Original product data from the marketplace provider
+    created_at                      timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at                      timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at                      timestamp with time zone,
+    iam_account_id                  bigint,
+    iam_user_id                     bigint,
+    CONSTRAINT marketplace_order_items_pkey PRIMARY KEY (id)
+);

--- a/schemas/marketplace_order_items_perspective.sql
+++ b/schemas/marketplace_order_items_perspective.sql
@@ -1,0 +1,36 @@
+-- PostgreSQL
+-- VIEW (read-only; re-run this file with CREATE OR REPLACE VIEW whenever the SELECT needs to change)
+
+CREATE OR REPLACE VIEW marketplace_order_items_perspective AS
+SELECT moi.id,
+    moi.uuid,
+    mpc.name,
+    moi.marketplace_order_id,
+    moi.marketplace_product_catalog_id,
+    moi.quantity,
+    mpc.quantity_in_inventory,
+    moi.price_per_item,
+    moi.total_price,
+    moi.modifiers,
+    moi.special_instructions,
+    moi.item_data,
+    mpc.sku,
+    moi.created_at,
+    moi.updated_at,
+    moi.deleted_at,
+    moi.iam_account_id,
+    moi.iam_user_id,
+    mo.delivery_method,
+    mp.name AS product_name,
+    mpv.name AS provider_name,
+    mo.external_order_number AS order_number,
+    mo.status,
+    mo.ordered_at,
+    mo.accepted_at,
+    mo.customer_note
+   FROM marketplace_order_items moi
+     JOIN marketplace_product_catalogs mpc ON moi.marketplace_product_catalog_id = mpc.id
+     JOIN marketplace_orders mo ON moi.marketplace_order_id = mo.id
+     JOIN marketplace_products mp ON mo.marketplace_product_id = mp.id
+     LEFT JOIN marketplace_providers mpv ON mo.marketplace_provider_id = mpv.id
+  WHERE moi.deleted_at IS NULL AND mo.deleted_at IS NULL;

--- a/schemas/marketplace_order_status_history.sql
+++ b/schemas/marketplace_order_status_history.sql
@@ -1,0 +1,18 @@
+-- PostgreSQL
+-- Table to track status changes for marketplace orders
+
+CREATE TABLE marketplace_order_status_history (
+    id                    bigint NOT NULL DEFAULT nextval('marketplace_order_status_history_id_seq'::regclass),
+    uuid                  uuid NOT NULL DEFAULT gen_random_uuid(),
+    marketplace_order_id  bigint NOT NULL, -- The order this status history belongs to
+    old_status            text NOT NULL, -- Previous status of the order
+    new_status            text NOT NULL, -- New status of the order
+    changed_at            timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP, -- When the status was changed
+    notes                 text, -- Optional notes about the status change
+    iam_account_id        bigint,
+    iam_user_id           bigint,
+    created_at            timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at            timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at            timestamp with time zone,
+    CONSTRAINT marketplace_order_status_history_pkey PRIMARY KEY (id)
+);

--- a/schemas/marketplace_orders.sql
+++ b/schemas/marketplace_orders.sql
@@ -1,0 +1,45 @@
+-- PostgreSQL
+-- Table to manage orders from marketplace providers
+
+CREATE TABLE marketplace_orders (
+    id                       bigint NOT NULL DEFAULT nextval('marketplace_orders_id_seq'::regclass),
+    uuid                     uuid NOT NULL DEFAULT gen_random_uuid(),
+    marketplace_market_id    bigint, -- The account that owns the order
+    marketplace_provider_id  bigint, -- The provider that manages the order
+    marketplace_product_id   bigint NOT NULL,
+    external_order_id        text, -- [skip]
+    external_order_number    text, -- Order number as provided by the marketplace provider
+    status                   text DEFAULT 'Accepted'::text, -- Current status of the order (e.g. pending, accepted, prepared, dispatched, delivered, cancelled)
+    ordered_at               timestamp with time zone DEFAULT CURRENT_TIMESTAMP, -- Timestamp when the order was placed
+    accepted_at              timestamp with time zone, -- Timestamp when the order was accepted by the provider
+    prepared_at              timestamp with time zone, -- Timestamp when the order was prepared
+    dispatched_at            timestamp with time zone, -- Timestamp when the order was dispatched for delivery
+    delivered_at             timestamp with time zone, -- Timestamp when the order was delivered to the customer
+    cancelled_at             timestamp with time zone, -- Timestamp when the order was cancelled
+    customer_data            json, -- Customer information such as name, email, phone number
+    delivery_address         json, -- Delivery address details if applicable
+    marketplace_metadata     json, -- Metadata related to the marketplace order
+    subtotal_amount          numeric(10,2) DEFAULT 0, -- Subtotal amount for the order before any fees or discounts
+    delivery_fee             numeric(10,2) DEFAULT 0, -- Delivery fee for the order
+    service_fee              numeric(10,2) DEFAULT 0, -- Service fee for the order
+    tax_amount               numeric(10,2) DEFAULT 0, -- Tax amount applied to the order
+    discount_amount          numeric(10,2) DEFAULT 0, -- Discount amount applied to the order
+    total_amount             numeric(10,2) DEFAULT 0, -- Total amount for the order after fees, taxes, and discounts
+    order_type               text DEFAULT 'external'::text, -- Type of order (e.g. delivery, pickup, dine-in)
+    delivery_method          text, -- Method of delivery (e.g. platform_delivery, self_pickup, restaurant_delivery)
+    estimated_delivery_time  timestamp with time zone, -- Estimated time for delivery or pickup
+    raw_order_data           json, -- Raw data from the marketplace provider
+    last_synced_at           timestamp with time zone DEFAULT CURRENT_TIMESTAMP, -- Timestamp when the order was last synced with the marketplace provider
+    sync_error_message       text, -- Error message if syncing fails
+    iam_account_id           bigint,
+    iam_user_id              bigint,
+    created_at               timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at               timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at               timestamp with time zone,
+    customer_note            text,
+    tags                     text[],
+    external_line_id         text, -- [skip]
+    provider                 text, -- Name of the marketplace provider managing the order
+    order_no                 text DEFAULT ((COALESCE(provider, 'KipHok'::text) || ' - '::text) || (id)::text), -- Generated order number combining provider name and order ID
+    CONSTRAINT marketplace_orders_pkey PRIMARY KEY (id)
+);

--- a/schemas/marketplace_product_catalog_mappings.sql
+++ b/schemas/marketplace_product_catalog_mappings.sql
@@ -1,0 +1,14 @@
+-- PostgreSQL
+-- Table to manage product catalogs from different marketplace providers
+
+CREATE TABLE marketplace_product_catalog_mappings (
+    id                              bigint NOT NULL DEFAULT nextval('marketplace_product_catalog_mappings_id_seq'::regclass),
+    uuid                            uuid NOT NULL DEFAULT gen_random_uuid(),
+    marketplace_product_catalog_id  bigint NOT NULL, -- The product catalog this entry belongs to
+    marketplace_provider_id         bigint NOT NULL, -- The provider this catalog belongs to
+    external_catalog_id             text NOT NULL, -- Unique identifier for the catalog in the marketplace provider system
+    created_at                      timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at                      timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at                      timestamp with time zone,
+    CONSTRAINT marketplace_product_catalog_mappings_pkey PRIMARY KEY (id)
+);

--- a/schemas/marketplace_product_catalogs.sql
+++ b/schemas/marketplace_product_catalogs.sql
@@ -1,0 +1,25 @@
+-- PostgreSQL
+
+CREATE TABLE marketplace_product_catalogs (
+    id                        bigint NOT NULL DEFAULT nextval('marketplace_product_catalogs_id_seq'::regclass),
+    uuid                      uuid DEFAULT gen_random_uuid(),
+    name                      text NOT NULL,
+    agreement                 text, -- [label:"The currency of the price will be the same with the market you are presenting your product. If the market is USD then its USD, if the market is EUR, then the price is EUR."]
+    args                      json, -- [label:"Arguements are the features or options that comes with this catalog item."]
+    price                     numeric(20,8) NOT NULL, -- [ui:money]
+    marketplace_product_id    bigint NOT NULL,
+    tags                      text[] NOT NULL DEFAULT '{}'::text[],
+    created_at                timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at                timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at                timestamp with time zone,
+    sku                       text,
+    trial_date                integer NOT NULL DEFAULT 0, -- [label:"If you can offer a free trial, how many days does a customer use this catalog item?"]
+    features                  text[], -- [label:"Features of this catalog item when you compare with other items. What is different ?"]
+    iam_user_id               bigint,
+    iam_account_id            bigint,
+    is_public                 boolean DEFAULT true,
+    quantity_in_inventory     integer NOT NULL DEFAULT '-1'::integer, -- [label:"The amount of the items you can sell right now."]
+    common_currency_id        bigint,
+    payment_gateway_mappings  json,
+    CONSTRAINT marketplace_product_catalogs_pkey PRIMARY KEY (id)
+);

--- a/schemas/marketplace_product_catalogs_perspective.sql
+++ b/schemas/marketplace_product_catalogs_perspective.sql
@@ -1,0 +1,25 @@
+-- PostgreSQL
+-- VIEW (read-only; re-run this file with CREATE OR REPLACE VIEW whenever the SELECT needs to change)
+
+CREATE OR REPLACE VIEW marketplace_product_catalogs_perspective AS
+SELECT id,
+    uuid,
+    name,
+    price,
+    args,
+    tags,
+    quantity_in_inventory,
+    trial_date,
+    sku,
+    is_public,
+    features,
+    marketplace_product_id,
+    ( SELECT n_mp.name
+           FROM marketplace_products n_mp
+          WHERE n_mp.id = c.marketplace_product_id) AS product,
+    iam_account_id,
+    iam_user_id,
+    created_at,
+    updated_at,
+    deleted_at
+   FROM marketplace_product_catalogs c;

--- a/schemas/marketplace_product_mappings.sql
+++ b/schemas/marketplace_product_mappings.sql
@@ -1,0 +1,14 @@
+-- PostgreSQL
+-- Table to manage mappings between marketplace products and their external identifiers in different providers
+
+CREATE TABLE marketplace_product_mappings (
+    id                       bigint NOT NULL DEFAULT nextval('marketplace_product_mappings_id_seq'::regclass),
+    uuid                     uuid NOT NULL DEFAULT gen_random_uuid(),
+    marketplace_product_id   bigint NOT NULL, -- The product this mapping belongs to
+    marketplace_provider_id  bigint NOT NULL, -- The provider this mapping is for
+    external_product_id      text NOT NULL, -- Unique identifier for the product in the marketplace provider system
+    created_at               timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at               timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at               timestamp with time zone,
+    CONSTRAINT marketplace_product_mappings_pkey PRIMARY KEY (id)
+);

--- a/schemas/marketplace_products.sql
+++ b/schemas/marketplace_products.sql
@@ -1,0 +1,37 @@
+-- PostgreSQL
+
+CREATE TABLE marketplace_products (
+    id                        bigint NOT NULL DEFAULT nextval('marketplace_products_id_seq'::regclass),
+    uuid                      uuid DEFAULT gen_random_uuid(),
+    name                      text NOT NULL, -- [label:"This will be the name of your product, like: Acme CRM Software"]
+    description               text, -- [ui:markdown][return:html][label:"Please give us a brief information about your product."]
+    content                   text, -- [ui:markdown][label:"This will be the content which your product will be explained detailed."]
+    highlights                text[], -- [label:"Tell us about your products highlighted features."]
+    after_sales_introduction  text, -- [ui:markdown]
+    support_content           text, -- [ui:markdown][label:"Tell us about how you provide support for your product"]
+    refund_policy             text, -- [ui:markdown][label:"What happens if the customer would like to make charge back."]
+    eula                      text, -- [label:"Please enter the end users licence agreement here."][ui:markdown]
+    subscription_type         subscription_type NOT NULL DEFAULT 'hourly'::subscription_type,
+    slug                      text, -- [ro]
+    version                   text,
+    product_type              product_type DEFAULT 'onetime'::product_type,
+    is_service                boolean DEFAULT false,
+    is_in_maintenance         boolean DEFAULT false,
+    is_public                 boolean DEFAULT false,
+    is_invisible              boolean DEFAULT false,
+    is_active                 boolean DEFAULT true,
+    common_category_id        bigint,
+    iam_account_id            bigint NOT NULL,
+    iam_user_id               bigint NOT NULL,
+    marketplace_market_id     bigint NOT NULL,
+    tags                      text[] DEFAULT '{}'::text[],
+    created_at                timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at                timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at                timestamp with time zone,
+    sales_pitch               text, -- [ui:markdown]
+    is_approved               boolean NOT NULL DEFAULT false, -- [ro]
+    marketplace_provider_id   bigint,
+    payment_gateway_mappings  json,
+    metadata                  jsonb,
+    CONSTRAINT marketplace_products_pkey PRIMARY KEY (id)
+);

--- a/schemas/marketplace_products_perspective.sql
+++ b/schemas/marketplace_products_perspective.sql
@@ -1,0 +1,73 @@
+-- PostgreSQL
+-- VIEW (read-only; re-run this file with CREATE OR REPLACE VIEW whenever the SELECT needs to change)
+
+CREATE OR REPLACE VIEW marketplace_products_perspective AS
+SELECT id,
+    uuid,
+    name,
+    description,
+    content,
+    highlights,
+    subscription_type,
+    slug,
+    version,
+    sales_pitch,
+    is_service,
+    is_in_maintenance,
+    is_public,
+    is_invisible,
+    is_active,
+    is_approved,
+    ( SELECT n_cc.name
+           FROM common_categories n_cc
+          WHERE n_cc.id = mp.common_category_id) AS category,
+    common_category_id,
+    ( SELECT n_mm.name
+           FROM marketplace_markets n_mm
+          WHERE n_mm.id = mp.marketplace_market_id) AS marketplace,
+    marketplace_market_id,
+    ( SELECT c_ia.name
+           FROM iam_accounts c_ia
+          WHERE c_ia.id = mp.iam_account_id) AS maintainer,
+    ( SELECT c_ia2.description
+           FROM iam_accounts c_ia2
+          WHERE c_ia2.id = mp.iam_account_id) AS about_maintainer,
+    ( SELECT n_ia.fullname
+           FROM iam_users n_ia
+          WHERE n_ia.id = mp.iam_user_id) AS responsible,
+    ( SELECT count(n_mpc.id) AS count
+           FROM marketplace_product_catalogs n_mpc
+          WHERE n_mpc.marketplace_product_id = mp.id) AS product_catalog_count,
+    ( SELECT
+                CASE
+                    WHEN count(n_mpc2.id) > 0 THEN true
+                    ELSE false
+                END AS "case"
+           FROM marketplace_product_catalogs n_mpc2
+          WHERE n_mpc2.marketplace_product_id = mp.id AND n_mpc2.trial_date > 0) AS has_free_trial,
+    ( SELECT n_mpc2.price
+           FROM marketplace_product_catalogs n_mpc2
+          WHERE n_mpc2.marketplace_product_id = mp.id
+          ORDER BY n_mpc2.price
+         LIMIT 1) AS starting_from,
+    ( SELECT n_cc.code
+           FROM common_currencies n_cc
+          WHERE n_cc.id = (( SELECT n_mpc3.common_currency_id
+                   FROM marketplace_product_catalogs n_mpc3
+                  WHERE n_mpc3.marketplace_product_id = mp.id
+                  ORDER BY n_mpc3.price
+                 LIMIT 1))) AS currency_code,
+    ( SELECT n_pa.meeting_link
+           FROM partnership_accounts n_pa
+          WHERE n_pa.iam_account_id = mp.iam_account_id) AS partner_meeting_link,
+    refund_policy,
+    after_sales_introduction,
+    support_content,
+    eula,
+    tags,
+    iam_account_id,
+    iam_user_id,
+    created_at,
+    updated_at,
+    deleted_at
+   FROM marketplace_products mp;

--- a/schemas/marketplace_providers.sql
+++ b/schemas/marketplace_providers.sql
@@ -1,0 +1,20 @@
+-- PostgreSQL
+
+CREATE TABLE marketplace_providers (
+    id                     bigint NOT NULL DEFAULT nextval('marketplace_providers_id_seq'::regclass),
+    uuid                   uuid NOT NULL DEFAULT gen_random_uuid(),
+    name                   text,
+    description            text,
+    action                 text,
+    url                    text,
+    marketplace_market_id  bigint,
+    iam_account_id         bigint,
+    iam_user_id            bigint,
+    created_at             timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at             timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at             timestamp with time zone,
+    api_config             json,
+    is_active              boolean DEFAULT true,
+    adapter                text, -- The adapter used for the provider, e.g. "trendyol_go" for Trendyol Go, "yemeksepeti" for Yemeksepeti, etc.
+    CONSTRAINT marketplace_providers_pkey PRIMARY KEY (id)
+);

--- a/schemas/marketplace_status_mappings.sql
+++ b/schemas/marketplace_status_mappings.sql
@@ -1,0 +1,12 @@
+-- PostgreSQL
+-- Table to manage status mappings between external marketplace provider statuses and normalized internal statuses
+
+CREATE TABLE marketplace_status_mappings (
+    id                       bigint NOT NULL DEFAULT nextval('marketplace_status_mappings_id_seq'::regclass),
+    marketplace_provider_id  bigint, -- The provider this status mapping belongs to
+    external_status          text NOT NULL, -- Status as provided by the marketplace provider
+    normalized_status        text NOT NULL, -- Normalized status used internally in the system
+    description              text,
+    created_at               timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT marketplace_status_mappings_pkey PRIMARY KEY (id)
+);

--- a/schemas/marketplace_subscriptions.sql
+++ b/schemas/marketplace_subscriptions.sql
@@ -1,0 +1,18 @@
+-- PostgreSQL
+
+CREATE TABLE marketplace_subscriptions (
+    id                              bigint NOT NULL DEFAULT nextval('marketplace_subscriptions_id_seq'::regclass),
+    uuid                            uuid DEFAULT gen_random_uuid(),
+    marketplace_product_catalog_id  bigint NOT NULL,
+    iam_account_id                  bigint NOT NULL,
+    iam_user_id                     bigint,
+    subscription_data               json,
+    subscription_starts_at          timestamp with time zone,
+    subscription_ends_at            timestamp with time zone,
+    is_valid                        boolean NOT NULL DEFAULT true,
+    tags                            text[] NOT NULL DEFAULT '{}'::text[],
+    created_at                      timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at                      timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at                      timestamp with time zone,
+    CONSTRAINT marketplace_subscriptions_pkey PRIMARY KEY (id)
+);


### PR DESCRIPTION
Introspected the live database schema (read-only) and generated one CREATE TABLE/VIEW file per table/view owned by this module under `schemas/`. No code changes.